### PR TITLE
Api improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "desmos-bindings"
 version = "0.1.0"
-authors = ["Leonardo Bragagnolo <leonardo@forbole.com>", "Paul Chen <paul@forbole.com>", "Manuel Turetta <manuel@forbole.com>"]
+authors = [
+    "Leonardo Bragagnolo <leonardo@forbole.com>",
+    "Paul Chen <paul@forbole.com>",
+    "Manuel Turetta <manuel@forbole.com>"
+]
 edition = "2018"
 description = "CosmWasm bindings to custom Desmos features"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = [
     "Leonardo Bragagnolo <leonardo@forbole.com>",
     "Paul Chen <paul@forbole.com>",
-    "Manuel Turetta <manuel@forbole.com>"
+    "Manuel Turetta <manuel@forbole.com>",
 ]
 edition = "2018"
 description = "CosmWasm bindings to custom Desmos features"

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -56,7 +56,7 @@ mod tests {
             query_types::QuerySubspaceResponse,
         },
     };
-    use cosmwasm_std::{Addr, Uint64};
+    use cosmwasm_std::Addr;
     use std::ops::Deref;
 
     #[test]
@@ -76,7 +76,7 @@ mod tests {
         let owned_deps = mock_dependencies_with_custom_querier(&[]);
         let deps = owned_deps.as_ref();
         let querier = SubspacesQuerier::new(deps.querier.deref());
-        let response = querier.query_subspace(Uint64::new(1)).unwrap();
+        let response = querier.query_subspace(1).unwrap();
         let expected = QuerySubspaceResponse {
             subspace: MockSubspacesQueries::get_mock_subspace(),
         };
@@ -90,7 +90,7 @@ mod tests {
         let querier = RelationshipsQuerier::new(deps.querier.deref());
         let response = querier
             .query_relationships(
-                Uint64::new(1),
+                1,
                 Some(Addr::unchecked("")),
                 Some(Addr::unchecked("")),
                 None,

--- a/src/profiles/msg_builder.rs
+++ b/src/profiles/msg_builder.rs
@@ -1,7 +1,7 @@
 use crate::profiles::models_app_links::{Data, TimeoutHeight};
 use crate::profiles::models_chain_links::{ChainConfig, ChainLinkAddr, Proof};
 use crate::profiles::msg::ProfilesMsg;
-use cosmwasm_std::{Addr, Uint64};
+use cosmwasm_std::Addr;
 
 pub struct ProfilesMsgBuilder {}
 
@@ -20,19 +20,19 @@ impl Default for ProfilesMsgBuilder {
 impl ProfilesMsgBuilder {
     pub fn save_profile(
         &self,
-        dtag: String,
+        dtag: &str,
         creator: Addr,
-        nickname: String,
-        bio: String,
-        profile_picture: String,
-        cover_picture: String,
+        nickname: &str,
+        bio: &str,
+        profile_picture: &str,
+        cover_picture: &str,
     ) -> ProfilesMsg {
         ProfilesMsg::SaveProfile {
-            dtag,
-            nickname,
-            bio,
-            profile_picture,
-            cover_picture,
+            dtag: dtag.to_owned(),
+            nickname: nickname.to_owned(),
+            bio: bio.to_owned(),
+            profile_picture: profile_picture.to_owned(),
+            cover_picture: cover_picture.to_owned(),
             creator,
         }
     }
@@ -47,12 +47,12 @@ impl ProfilesMsgBuilder {
 
     pub fn accept_dtag_transfer_request(
         &self,
-        new_dtag: String,
+        new_dtag: &str,
         sender: Addr,
         receiver: Addr,
     ) -> ProfilesMsg {
         ProfilesMsg::AcceptDtagTransferRequest {
-            new_dtag,
+            new_dtag: new_dtag.to_owned(),
             sender,
             receiver,
         }
@@ -89,7 +89,7 @@ impl ProfilesMsgBuilder {
         source_port: String,
         source_channel: String,
         timeout_height: TimeoutHeight,
-        timeout_timestamp: Uint64,
+        timeout_timestamp: u64,
     ) -> ProfilesMsg {
         ProfilesMsg::LinkApplication {
             sender,
@@ -98,7 +98,7 @@ impl ProfilesMsgBuilder {
             source_port,
             source_channel,
             timeout_height,
-            timeout_timestamp,
+            timeout_timestamp: timeout_timestamp.into(),
         }
     }
 }
@@ -118,12 +118,12 @@ mod tests {
     fn test_save_profile() {
         let builder = ProfilesMsgBuilder::default();
         let msg = builder.save_profile(
-            "test".to_string(),
+            "test",
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-            "".to_string(),
-            "".to_string(),
-            "".to_string(),
-            "".to_string(),
+            "",
+            "",
+            "",
+            "",
         );
         let expected = ProfilesMsg::SaveProfile {
             dtag: "test".to_string(),
@@ -166,7 +166,7 @@ mod tests {
     fn test_accept_dtag_transfer_request() {
         let builder = ProfilesMsgBuilder::default();
         let msg = builder.accept_dtag_transfer_request(
-            "test".to_string(),
+            "test",
             Addr::unchecked("cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t"),
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
         );
@@ -273,7 +273,7 @@ mod tests {
             "123".to_string(),
             "123".to_string(),
             timeout_height.clone(),
-            Uint64::new(1),
+            1,
         );
         let expected = ProfilesMsg::LinkApplication {
             sender: Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),

--- a/src/profiles/querier.rs
+++ b/src/profiles/querier.rs
@@ -82,9 +82,11 @@ impl<'a> ProfilesQuerier<'a> {
 
     pub fn query_application_link_by_client_id(
         &self,
-        client_id: String,
+        client_id: &str,
     ) -> StdResult<QueryApplicationLinkByClientIDResponse> {
-        let request = DesmosQuery::Profiles(ProfilesQuery::ApplicationLinkByChainID { client_id });
+        let request = DesmosQuery::Profiles(ProfilesQuery::ApplicationLinkByChainID {
+            client_id: client_id.to_owned()
+        });
 
         let res: QueryApplicationLinkByClientIDResponse = self.querier.query(&request.into())?;
         Ok(res)
@@ -190,7 +192,7 @@ mod tests {
         let profiles_querier = ProfilesQuerier::new(deps.querier.deref());
 
         let response = profiles_querier
-            .query_application_link_by_client_id("".to_string())
+            .query_application_link_by_client_id("")
             .unwrap();
         let expected = QueryApplicationLinkByClientIDResponse {
             link: MockProfilesQueries::get_mock_application_link(),

--- a/src/profiles/querier.rs
+++ b/src/profiles/querier.rs
@@ -85,7 +85,7 @@ impl<'a> ProfilesQuerier<'a> {
         client_id: &str,
     ) -> StdResult<QueryApplicationLinkByClientIDResponse> {
         let request = DesmosQuery::Profiles(ProfilesQuery::ApplicationLinkByChainID {
-            client_id: client_id.to_owned()
+            client_id: client_id.to_owned(),
         });
 
         let res: QueryApplicationLinkByClientIDResponse = self.querier.query(&request.into())?;

--- a/src/relationships/msg_builder.rs
+++ b/src/relationships/msg_builder.rs
@@ -57,12 +57,7 @@ impl RelationshipsMsgBuilder {
         }
     }
 
-    pub fn unblock_user(
-        &self,
-        blocker: Addr,
-        blocked: Addr,
-        subspace_id: u64,
-    ) -> RelationshipsMsg {
+    pub fn unblock_user(&self, blocker: Addr, blocked: Addr, subspace_id: u64) -> RelationshipsMsg {
         RelationshipsMsg::UnblockUser {
             blocker,
             blocked,

--- a/src/relationships/msg_builder.rs
+++ b/src/relationships/msg_builder.rs
@@ -1,5 +1,5 @@
 use crate::relationships::msg::RelationshipsMsg;
-use cosmwasm_std::{Addr, Uint64};
+use cosmwasm_std::Addr;
 
 pub struct RelationshipsMsgBuilder {}
 
@@ -20,12 +20,12 @@ impl RelationshipsMsgBuilder {
         &self,
         sender: Addr,
         counterparty: Addr,
-        subspace_id: Uint64,
+        subspace_id: u64,
     ) -> RelationshipsMsg {
         RelationshipsMsg::CreateRelationship {
             signer: sender,
             counterparty,
-            subspace_id,
+            subspace_id: subspace_id.into(),
         }
     }
 
@@ -33,12 +33,12 @@ impl RelationshipsMsgBuilder {
         &self,
         user: Addr,
         counterparty: Addr,
-        subspace_id: Uint64,
+        subspace_id: u64,
     ) -> RelationshipsMsg {
         RelationshipsMsg::DeleteRelationship {
             signer: user,
             counterparty,
-            subspace_id,
+            subspace_id: subspace_id.into(),
         }
     }
 
@@ -47,13 +47,13 @@ impl RelationshipsMsgBuilder {
         blocker: Addr,
         blocked: Addr,
         reason: String,
-        subspace_id: Uint64,
+        subspace_id: u64,
     ) -> RelationshipsMsg {
         RelationshipsMsg::BlockUser {
             blocker,
             blocked,
             reason,
-            subspace_id,
+            subspace_id: subspace_id.into(),
         }
     }
 
@@ -61,12 +61,12 @@ impl RelationshipsMsgBuilder {
         &self,
         blocker: Addr,
         blocked: Addr,
-        subspace_id: Uint64,
+        subspace_id: u64,
     ) -> RelationshipsMsg {
         RelationshipsMsg::UnblockUser {
             blocker,
             blocked,
-            subspace_id,
+            subspace_id: subspace_id.into(),
         }
     }
 }
@@ -82,7 +82,7 @@ mod tests {
         let msg = builder.create_relationship(
             Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-            Uint64::new(1),
+            1,
         );
         let expected = RelationshipsMsg::CreateRelationship {
             signer: Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
@@ -98,7 +98,7 @@ mod tests {
         let msg = builder.delete_relationship(
             Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-            Uint64::new(1),
+            1,
         );
         let expected = RelationshipsMsg::DeleteRelationship {
             signer: Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
@@ -115,7 +115,7 @@ mod tests {
             Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
             "test".to_string(),
-            Uint64::new(1),
+            1,
         );
         let expected = RelationshipsMsg::BlockUser {
             blocker: Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
@@ -132,7 +132,7 @@ mod tests {
         let msg = builder.unblock_user(
             Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-            Uint64::new(1),
+            1,
         );
         let expected = RelationshipsMsg::UnblockUser {
             blocker: Addr::unchecked("cosmos18xnmlzqrqr6zt526pnczxe65zk3f4xgmndpxn2"),

--- a/src/relationships/querier.rs
+++ b/src/relationships/querier.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     types::PageRequest,
 };
-use cosmwasm_std::{Addr, Querier, QuerierWrapper, StdResult, Uint64};
+use cosmwasm_std::{Addr, Querier, QuerierWrapper, StdResult};
 
 pub struct RelationshipsQuerier<'a> {
     querier: QuerierWrapper<'a, DesmosQuery>,
@@ -21,13 +21,13 @@ impl<'a> RelationshipsQuerier<'a> {
 
     pub fn query_relationships(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         user: Option<Addr>,
         counterparty: Option<Addr>,
         pagination: Option<PageRequest>,
     ) -> StdResult<QueryRelationshipsResponse> {
         let request = DesmosQuery::Relationships(RelationshipsQuery::Relationships {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             user,
             counterparty,
             pagination,
@@ -39,13 +39,13 @@ impl<'a> RelationshipsQuerier<'a> {
 
     pub fn query_blocks(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         blocker: Option<Addr>,
         blocked: Option<Addr>,
         pagination: Option<PageRequest>,
     ) -> StdResult<QueryBlocksResponse> {
         let request = DesmosQuery::Relationships(RelationshipsQuery::Blocks {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             blocker,
             blocked,
             pagination,
@@ -66,7 +66,7 @@ mod tests {
             querier::RelationshipsQuerier,
         },
     };
-    use cosmwasm_std::{Addr, Uint64};
+    use cosmwasm_std::Addr;
     use std::ops::Deref;
 
     #[test]
@@ -77,7 +77,7 @@ mod tests {
 
         let response = relationships_querier
             .query_relationships(
-                Uint64::new(0),
+                0,
                 Some(Addr::unchecked("")),
                 Some(Addr::unchecked("")),
                 None,
@@ -99,7 +99,7 @@ mod tests {
 
         let response = relationships_querier
             .query_blocks(
-                Uint64::new(0),
+                0,
                 Some(Addr::unchecked("")),
                 Some(Addr::unchecked("")),
                 None,

--- a/src/subspaces/msg_builder.rs
+++ b/src/subspaces/msg_builder.rs
@@ -106,12 +106,7 @@ impl SubspacesMsgBuilder {
         }
     }
 
-    pub fn delete_user_group(
-        &self,
-        subspace_id: u64,
-        group_id: u32,
-        signer: Addr,
-    ) -> SubspacesMsg {
+    pub fn delete_user_group(&self, subspace_id: u64, group_id: u32, signer: Addr) -> SubspacesMsg {
         SubspacesMsg::DeleteUserGroup {
             subspace_id: subspace_id.into(),
             group_id,
@@ -167,8 +162,8 @@ impl SubspacesMsgBuilder {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::Uint64;
     use super::*;
+    use cosmwasm_std::Uint64;
 
     #[test]
     fn test_create_subspace() {

--- a/src/subspaces/msg_builder.rs
+++ b/src/subspaces/msg_builder.rs
@@ -1,5 +1,5 @@
 use crate::subspaces::msg::SubspacesMsg;
-use cosmwasm_std::{Addr, Uint64};
+use cosmwasm_std::Addr;
 
 pub struct SubspacesMsgBuilder;
 
@@ -18,15 +18,15 @@ impl Default for SubspacesMsgBuilder {
 impl SubspacesMsgBuilder {
     pub fn create_subspace(
         &self,
-        name: String,
-        description: String,
+        name: &str,
+        description: &str,
         treasury: Addr,
         owner: Addr,
         creator: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::CreateSubspace {
-            name,
-            description,
+            name: name.to_owned(),
+            description: description.to_owned(),
             treasury,
             owner,
             creator,
@@ -35,38 +35,38 @@ impl SubspacesMsgBuilder {
 
     pub fn edit_subspace(
         &self,
-        name: String,
-        description: String,
+        name: &str,
+        description: &str,
         treasury: Addr,
         owner: Addr,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::EditSubspace {
-            name,
-            description,
+            name: name.to_owned(),
+            description: description.to_owned(),
             treasury,
             owner,
             signer,
         }
     }
 
-    pub fn delete_subspace(&self, subspace_id: Uint64, signer: Addr) -> SubspacesMsg {
+    pub fn delete_subspace(&self, subspace_id: u64, signer: Addr) -> SubspacesMsg {
         SubspacesMsg::DeleteSubspace {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             signer,
         }
     }
 
     pub fn create_user_group(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         name: String,
         description: String,
         default_permissions: u32,
         creator: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::CreateUserGroup {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             name,
             description,
             default_permissions,
@@ -76,14 +76,14 @@ impl SubspacesMsgBuilder {
 
     pub fn edit_user_group(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
         name: String,
         description: String,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::EditUserGroup {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
             name,
             description,
@@ -93,13 +93,13 @@ impl SubspacesMsgBuilder {
 
     pub fn set_user_group_permissions(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
         permissions: u32,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::SetUserGroupPermissions {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
             permissions,
             signer,
@@ -108,12 +108,12 @@ impl SubspacesMsgBuilder {
 
     pub fn delete_user_group(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::DeleteUserGroup {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
             signer,
         }
@@ -121,13 +121,13 @@ impl SubspacesMsgBuilder {
 
     pub fn add_user_to_user_group(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
         user: Addr,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::AddUserToUserGroup {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
             user,
             signer,
@@ -136,13 +136,13 @@ impl SubspacesMsgBuilder {
 
     pub fn remove_user_from_user_group(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
         user: Addr,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::RemoveUserFromUserGroup {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
             user,
             signer,
@@ -151,13 +151,13 @@ impl SubspacesMsgBuilder {
 
     pub fn set_user_permissions(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         user: Addr,
         permissions: u32,
         signer: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::SetUserPermissions {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             user,
             permissions,
             signer,
@@ -167,14 +167,15 @@ impl SubspacesMsgBuilder {
 
 #[cfg(test)]
 mod tests {
+    use cosmwasm_std::Uint64;
     use super::*;
 
     #[test]
     fn test_create_subspace() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.create_subspace(
-            "test".to_string(),
-            "test".to_string(),
+            "test",
+            "test",
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
             Addr::unchecked("cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t"),
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
@@ -193,8 +194,8 @@ mod tests {
     fn test_edit_subspace() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.edit_subspace(
-            "test".to_string(),
-            "test".to_string(),
+            "test",
+            "test",
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
             Addr::unchecked("cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t"),
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
@@ -213,7 +214,7 @@ mod tests {
     fn test_delete_subspace() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.delete_subspace(
-            Uint64::new(1),
+            1,
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
         );
         let expected = SubspacesMsg::DeleteSubspace {
@@ -227,7 +228,7 @@ mod tests {
     fn test_create_user_group() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.create_user_group(
-            Uint64::new(1),
+            1,
             "test".to_string(),
             "test".to_string(),
             1,
@@ -247,7 +248,7 @@ mod tests {
     fn test_edit_user_group() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.edit_user_group(
-            Uint64::new(1),
+            1,
             1,
             "test".to_string(),
             "test".to_string(),
@@ -267,7 +268,7 @@ mod tests {
     fn test_set_user_group_permissions() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.set_user_group_permissions(
-            Uint64::new(1),
+            1,
             1,
             1,
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
@@ -285,7 +286,7 @@ mod tests {
     fn test_delete_user_group() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.delete_user_group(
-            Uint64::new(1),
+            1,
             1,
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
         );
@@ -301,7 +302,7 @@ mod tests {
     fn test_add_user_to_user_group() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.add_user_to_user_group(
-            Uint64::new(1),
+            1,
             1,
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
             Addr::unchecked("cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t"),
@@ -319,7 +320,7 @@ mod tests {
     fn test_remove_user_to_user_group() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.remove_user_from_user_group(
-            Uint64::new(1),
+            1,
             1,
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
             Addr::unchecked("cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t"),
@@ -337,7 +338,7 @@ mod tests {
     fn test_set_user_permissions() {
         let builder = SubspacesMsgBuilder::default();
         let msg = builder.set_user_permissions(
-            Uint64::new(1),
+            1,
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
             1,
             Addr::unchecked("cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t"),

--- a/src/subspaces/querier.rs
+++ b/src/subspaces/querier.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Querier, QuerierWrapper, StdResult, Uint64};
+use cosmwasm_std::{Addr, Querier, QuerierWrapper, StdResult};
 
 use crate::{
     query::DesmosQuery,
@@ -34,19 +34,21 @@ impl<'a> SubspacesQuerier<'a> {
         Ok(res)
     }
 
-    pub fn query_subspace(&self, subspace_id: Uint64) -> StdResult<QuerySubspaceResponse> {
-        let request = DesmosQuery::from(SubspacesQuery::Subspace { subspace_id });
+    pub fn query_subspace(&self, subspace_id: u64) -> StdResult<QuerySubspaceResponse> {
+        let request = DesmosQuery::from(SubspacesQuery::Subspace {
+            subspace_id: subspace_id.into(),
+        });
         let res: QuerySubspaceResponse = self.querier.query(&request.into())?;
         Ok(res)
     }
 
     pub fn query_user_groups(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         pagination: Option<PageRequest>,
     ) -> StdResult<QueryUserGroupsResponse> {
         let request = DesmosQuery::from(SubspacesQuery::UserGroups {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             pagination,
         });
         let res: QueryUserGroupsResponse = self.querier.query(&request.into())?;
@@ -55,11 +57,11 @@ impl<'a> SubspacesQuerier<'a> {
 
     pub fn query_user_group(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
     ) -> StdResult<QueryUserGroupResponse> {
         let request = DesmosQuery::from(SubspacesQuery::UserGroup {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
         });
         let res: QueryUserGroupResponse = self.querier.query(&request.into())?;
@@ -68,12 +70,12 @@ impl<'a> SubspacesQuerier<'a> {
 
     pub fn query_user_group_members(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         group_id: u32,
         pagination: Option<PageRequest>,
     ) -> StdResult<QueryUserGroupMembersResponse> {
         let request = DesmosQuery::from(SubspacesQuery::UserGroupMembers {
-            subspace_id,
+            subspace_id: subspace_id.into(),
             group_id,
             pagination,
         });
@@ -83,10 +85,13 @@ impl<'a> SubspacesQuerier<'a> {
 
     pub fn query_user_permissions(
         &self,
-        subspace_id: Uint64,
+        subspace_id: u64,
         user: Addr,
     ) -> StdResult<QueryUserPermissionsResponse> {
-        let request = DesmosQuery::from(SubspacesQuery::UserPermissions { subspace_id, user });
+        let request = DesmosQuery::from(SubspacesQuery::UserPermissions {
+            subspace_id: subspace_id.into(),
+            user,
+        });
         let res: QueryUserPermissionsResponse = self.querier.query(&request.into())?;
         Ok(res)
     }
@@ -118,7 +123,7 @@ mod tests {
         let owned_deps = mock_dependencies_with_custom_querier(&[]);
         let deps = owned_deps.as_ref();
         let querier = SubspacesQuerier::new(deps.querier.deref());
-        let response = querier.query_subspace(Uint64::new(1));
+        let response = querier.query_subspace(1);
         let expected = QuerySubspaceResponse {
             subspace: MockSubspacesQueries::get_mock_subspace(),
         };
@@ -130,7 +135,7 @@ mod tests {
         let owned_deps = mock_dependencies_with_custom_querier(&[]);
         let deps = owned_deps.as_ref();
         let querier = SubspacesQuerier::new(deps.querier.deref());
-        let response = querier.query_user_groups(Uint64::new(1), Default::default());
+        let response = querier.query_user_groups(1, Default::default());
         let expected = QueryUserGroupsResponse {
             groups: vec![MockSubspacesQueries::get_mock_user_group()],
             pagination: Default::default(),
@@ -143,7 +148,7 @@ mod tests {
         let owned_deps = mock_dependencies_with_custom_querier(&[]);
         let deps = owned_deps.as_ref();
         let querier = SubspacesQuerier::new(deps.querier.deref());
-        let response = querier.query_user_group(Uint64::new(1), 1);
+        let response = querier.query_user_group(1, 1);
         let expected = QueryUserGroupResponse {
             group: MockSubspacesQueries::get_mock_user_group(),
         };
@@ -155,7 +160,7 @@ mod tests {
         let owned_deps = mock_dependencies_with_custom_querier(&[]);
         let deps = owned_deps.as_ref();
         let querier = SubspacesQuerier::new(deps.querier.deref());
-        let response = querier.query_user_group_members(Uint64::new(1), 1, Default::default());
+        let response = querier.query_user_group_members(1, 1, Default::default());
         let expected = QueryUserGroupMembersResponse {
             members: vec![MockSubspacesQueries::get_mock_group_member()],
             pagination: Default::default(),
@@ -169,7 +174,7 @@ mod tests {
         let deps = owned_deps.as_ref();
         let querier = SubspacesQuerier::new(deps.querier.deref());
         let response = querier.query_user_permissions(
-            Uint64::new(1),
+            1,
             Addr::unchecked("cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
         );
         let expected = QueryUserPermissionsResponse {


### PR DESCRIPTION
This PR aims to improve the bindings API reducing the amount of boilerprate code that a developer have to write.

This PR improve the following things:
- Replaced `Uint64` with `u64`, with this a developer don't need to call `Uint64::from`;
- Replaced String with &str, with this a developer don't need to clone or give up ownership of strings.