### PR TITLE
fix: rename query `AppLinks` into `ApplicationLinks`

### DIFF
--- a/packages/bindings/src/profiles/mock.rs
+++ b/packages/bindings/src/profiles/mock.rs
@@ -131,7 +131,7 @@ pub fn mock_profiles_query_response(query: &ProfilesQuery) -> ContractResult<Bin
                 pagination: Default::default(),
             })
         }
-        ProfilesQuery::AppLinks { .. } => {
+        ProfilesQuery::ApplicationLinks { .. } => {
             let app_link = MockProfilesQueries::get_mock_application_link();
             to_binary(&QueryApplicationLinksResponse {
                 links: vec![app_link],
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_query_app_links() {
-        let query = ProfilesQuery::AppLinks {
+        let query = ProfilesQuery::ApplicationLinks {
             user: Some(Addr::unchecked("")),
             application: Some("".to_string()),
             username: Some("".to_string()),

--- a/packages/bindings/src/profiles/querier.rs
+++ b/packages/bindings/src/profiles/querier.rs
@@ -196,7 +196,7 @@ impl<'a> ProfilesQuerier<'a> {
         username: Option<String>,
         pagination: Option<PageRequest>,
     ) -> StdResult<QueryApplicationLinksResponse> {
-        let request = DesmosQuery::Profiles(ProfilesQuery::AppLinks {
+        let request = DesmosQuery::Profiles(ProfilesQuery::ApplicationLinks {
             user,
             application,
             username,

--- a/packages/bindings/src/profiles/query.rs
+++ b/packages/bindings/src/profiles/query.rs
@@ -36,7 +36,7 @@ pub enum ProfilesQuery {
         pagination: Option<PageRequest>,
     },
     /// Message to query the application links.
-    AppLinks {
+    ApplicationLinks {
         /// Address associated for which the link should be searched.
         /// If `None` queries all the performed application links.
         user: Option<Addr>,


### PR DESCRIPTION
This PR renames the query method `AppLinks` into `ApplicationLinks` in order to fit the endpoint defined in [`profiles/query.proto`](https://github.com/desmos-labs/desmos/blob/master/proto/desmos/profiles/v2/query.proto#L48).