### PR TITLE
chore: improve mocks lib

### DIFF
--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -24,7 +24,5 @@ pub mod relationships;
 pub mod reports;
 #[cfg(feature = "subspaces")]
 pub mod subspaces;
-#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
-pub mod test_utils;
 
 pub mod types;

--- a/packages/bindings/src/mocks/mock_app.rs
+++ b/packages/bindings/src/mocks/mock_app.rs
@@ -947,7 +947,7 @@ mod tests {
     use super::*;
     use crate::{
         posts::{
-            mocks::get_mocked_post, models_query::QueryPostResponse, msg::PostsMsg,
+            mocks::MockPostsQueries, models_query::QueryPostResponse, msg::PostsMsg,
             querier::PostsQuerier,
         },
         profiles::{
@@ -1096,7 +1096,7 @@ mod tests {
         let querier = PostsQuerier::new(app_querier.deref());
         let response = querier.query_post(1, 1).unwrap();
         let expected = QueryPostResponse {
-            post: get_mocked_post(1u64.into(), 1u64.into()),
+            post: MockPostsQueries::get_mocked_post(1u64.into(), 1u64.into()),
         };
         assert_eq!(expected, response)
     }

--- a/packages/bindings/src/mocks/mock_app.rs
+++ b/packages/bindings/src/mocks/mock_app.rs
@@ -963,7 +963,7 @@ mod tests {
             msg::RelationshipsMsg, querier::RelationshipsQuerier,
         },
         reports::{
-            mocks::get_mocked_report, models_query::QueryReportResponse, msg::ReportsMsg,
+            mocks::MockReportsQueries, models_query::QueryReportResponse, msg::ReportsMsg,
             querier::ReportsQuerier,
         },
         subspaces::{
@@ -1121,7 +1121,7 @@ mod tests {
         let querier = ReportsQuerier::new(app_querier.deref());
         let response = querier.query_report(1, 1).unwrap();
         let expected = QueryReportResponse {
-            report: get_mocked_report(&1u64.into()),
+            report: MockReportsQueries::get_mocked_report(&1u64.into()),
         };
         assert_eq!(expected, response)
     }

--- a/packages/bindings/src/mocks/mock_queriers.rs
+++ b/packages/bindings/src/mocks/mock_queriers.rs
@@ -56,11 +56,8 @@ pub fn mock_dependencies_with_custom_querier(
 
 #[cfg(test)]
 mod tests {
-    use crate::reports::mocks::get_mocked_report;
-    use crate::reports::models_query::QueryReportResponse;
-    use crate::reports::querier::ReportsQuerier;
     use crate::{
-        mocks::mock_dependencies_with_custom_querier,
+        mocks::mock_queriers::mock_dependencies_with_custom_querier,
         profiles::{
             mocks::MockProfilesQueries, models_query::QueryProfileResponse,
             querier::ProfilesQuerier,
@@ -72,6 +69,9 @@ mod tests {
         relationships::{
             mocks::MockRelationshipsQueries, models_query::QueryRelationshipsResponse,
             querier::RelationshipsQuerier,
+        },
+        reports::{
+            mocks::MockReportsQueries, models_query::QueryReportResponse, querier::ReportsQuerier,
         },
         subspaces::{
             mocks::MockSubspacesQueries, models_query::QuerySubspaceResponse,
@@ -145,7 +145,7 @@ mod tests {
         let querier = ReportsQuerier::new(deps.querier.deref());
         let response = querier.query_report(1, 1).unwrap();
         let expected = QueryReportResponse {
-            report: get_mocked_report(&Uint64::new(1)),
+            report: MockReportsQueries::get_mocked_report(&Uint64::new(1)),
         };
         assert_eq!(expected, response)
     }

--- a/packages/bindings/src/mocks/mod.rs
+++ b/packages/bindings/src/mocks/mod.rs
@@ -1,0 +1,2 @@
+pub mod mock_app;
+pub mod mock_queriers;

--- a/packages/bindings/src/posts/mocks.rs
+++ b/packages/bindings/src/posts/mocks.rs
@@ -8,147 +8,153 @@ use crate::posts::models_query::{
 use crate::posts::query::PostsQuery;
 use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, Uint64};
 
-/// Functions that mocks the posts inside a subspace.
-pub fn get_mocked_subspace_posts(subspace_id: &Uint64) -> Vec<Post> {
-    vec![
-        Post {
-            subspace_id: *subspace_id,
-            section_id: 0,
-            eternal_id: None,
-            text: None,
-            entities: None,
-            tags: vec![],
-            author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
-            id: Uint64::new(0),
-            referenced_posts: vec![],
-            reply_settings: ReplySetting::Everyone,
-            creation_date: "".to_string(),
-            conversation_id: None,
-            last_edit_date: None,
-        },
-        Post {
-            subspace_id: *subspace_id,
-            section_id: 0,
-            eternal_id: None,
-            text: None,
-            entities: None,
-            tags: vec![],
-            author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
-            id: Uint64::new(1),
-            referenced_posts: vec![],
-            reply_settings: ReplySetting::Everyone,
-            creation_date: "".to_string(),
-            conversation_id: None,
-            last_edit_date: None,
-        },
-    ]
-}
+/// Struct that contains some utility methods to mock data of the Desmos
+/// x/posts module.
+pub struct MockPostsQueries {}
 
-/// Functions that mocks the posts inside a section.
-pub fn get_mocked_section_posts(subspace_id: &Uint64, section_id: &u32) -> Vec<Post> {
-    vec![
-        Post {
-            subspace_id: *subspace_id,
-            section_id: *section_id,
-            eternal_id: None,
-            text: None,
-            entities: None,
-            tags: vec![],
-            author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
-            id: Uint64::new(0),
-            referenced_posts: vec![],
-            reply_settings: ReplySetting::Everyone,
-            creation_date: "".to_string(),
-            conversation_id: None,
-            last_edit_date: None,
-        },
-        Post {
-            subspace_id: *subspace_id,
-            section_id: *section_id,
-            eternal_id: None,
-            text: None,
-            entities: None,
-            tags: vec![],
-            author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
-            id: Uint64::new(1),
-            referenced_posts: vec![],
-            reply_settings: ReplySetting::Everyone,
-            creation_date: "".to_string(),
-            conversation_id: None,
-            last_edit_date: None,
-        },
-    ]
-}
-
-/// Functions that mocks the post returned from the query post request.
-pub fn get_mocked_post(post_id: Uint64, subspace_id: Uint64) -> Post {
-    Post {
-        id: post_id,
-        subspace_id,
-        section_id: 0,
-        eternal_id: None,
-        text: None,
-        entities: None,
-        tags: vec![],
-        author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
-        conversation_id: None,
-        referenced_posts: vec![],
-        reply_settings: ReplySetting::Unspecified,
-        creation_date: "".to_string(),
-        last_edit_date: None,
+impl MockPostsQueries {
+    /// Functions that mocks the posts inside a subspace.
+    pub fn get_mocked_subspace_posts(subspace_id: &Uint64) -> Vec<Post> {
+        vec![
+            Post {
+                subspace_id: *subspace_id,
+                section_id: 0,
+                eternal_id: None,
+                text: None,
+                entities: None,
+                tags: vec![],
+                author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+                id: Uint64::new(0),
+                referenced_posts: vec![],
+                reply_settings: ReplySetting::Everyone,
+                creation_date: "".to_string(),
+                conversation_id: None,
+                last_edit_date: None,
+            },
+            Post {
+                subspace_id: *subspace_id,
+                section_id: 0,
+                eternal_id: None,
+                text: None,
+                entities: None,
+                tags: vec![],
+                author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+                id: Uint64::new(1),
+                referenced_posts: vec![],
+                reply_settings: ReplySetting::Everyone,
+                creation_date: "".to_string(),
+                conversation_id: None,
+                last_edit_date: None,
+            },
+        ]
     }
-}
 
-/// Functions that mocks the attachments of a post.
-pub fn get_mocked_post_attachments(subspace_id: &Uint64, post_id: &Uint64) -> Vec<Attachment> {
-    vec![
-        Attachment {
+    /// Functions that mocks the posts inside a section.
+    pub fn get_mocked_section_posts(subspace_id: &Uint64, section_id: &u32) -> Vec<Post> {
+        vec![
+            Post {
+                subspace_id: *subspace_id,
+                section_id: *section_id,
+                eternal_id: None,
+                text: None,
+                entities: None,
+                tags: vec![],
+                author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+                id: Uint64::new(0),
+                referenced_posts: vec![],
+                reply_settings: ReplySetting::Everyone,
+                creation_date: "".to_string(),
+                conversation_id: None,
+                last_edit_date: None,
+            },
+            Post {
+                subspace_id: *subspace_id,
+                section_id: *section_id,
+                eternal_id: None,
+                text: None,
+                entities: None,
+                tags: vec![],
+                author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+                id: Uint64::new(1),
+                referenced_posts: vec![],
+                reply_settings: ReplySetting::Everyone,
+                creation_date: "".to_string(),
+                conversation_id: None,
+                last_edit_date: None,
+            },
+        ]
+    }
+
+    /// Functions that mocks the post returned from the query post request.
+    pub fn get_mocked_post(post_id: Uint64, subspace_id: Uint64) -> Post {
+        Post {
+            id: post_id,
+            subspace_id,
+            section_id: 0,
+            eternal_id: None,
+            text: None,
+            entities: None,
+            tags: vec![],
+            author: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+            conversation_id: None,
+            referenced_posts: vec![],
+            reply_settings: ReplySetting::Unspecified,
+            creation_date: "".to_string(),
+            last_edit_date: None,
+        }
+    }
+
+    /// Functions that mocks the attachments of a post.
+    pub fn get_mocked_post_attachments(subspace_id: &Uint64, post_id: &Uint64) -> Vec<Attachment> {
+        vec![
+            Attachment {
+                subspace_id: *subspace_id,
+                post_id: *post_id,
+                id: 0,
+                content: PostAttachment::Media {
+                    uri: "ftp://domain.io/image.png".to_string(),
+                    mime_type: "image/png".to_string(),
+                }
+                .into(),
+            },
+            Attachment {
+                subspace_id: *subspace_id,
+                post_id: *post_id,
+                id: 1,
+                content: PostAttachment::Media {
+                    uri: "ftp://domain.io/image2.png".to_string(),
+                    mime_type: "image/png".to_string(),
+                }
+                .into(),
+            },
+        ]
+    }
+
+    /// Functions that mocks the poll answers.
+    pub fn get_mocked_poll_answers(
+        subspace_id: &Uint64,
+        post_id: &Uint64,
+        poll_id: &u32,
+        user: &Option<Addr>,
+    ) -> Vec<UserAnswer> {
+        vec![UserAnswer {
             subspace_id: *subspace_id,
             post_id: *post_id,
-            id: 0,
-            content: PostAttachment::Media {
-                uri: "ftp://domain.io/image.png".to_string(),
-                mime_type: "image/png".to_string(),
-            }
-            .into(),
-        },
-        Attachment {
-            subspace_id: *subspace_id,
-            post_id: *post_id,
-            id: 1,
-            content: PostAttachment::Media {
-                uri: "ftp://domain.io/image2.png".to_string(),
-                mime_type: "image/png".to_string(),
-            }
-            .into(),
-        },
-    ]
-}
-
-/// Functions that mocks the poll answers.
-pub fn get_mocked_poll_answers(
-    subspace_id: &Uint64,
-    post_id: &Uint64,
-    poll_id: &u32,
-    user: &Option<Addr>,
-) -> Vec<UserAnswer> {
-    vec![UserAnswer {
-        subspace_id: *subspace_id,
-        post_id: *post_id,
-        poll_id: *poll_id,
-        answers_indexes: vec![0],
-        user: user.as_ref().map_or(
-            Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
-            |addr| addr.clone(),
-        ),
-    }]
+            poll_id: *poll_id,
+            answers_indexes: vec![0],
+            user: user.as_ref().map_or(
+                Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+                |addr| addr.clone(),
+            ),
+        }]
+    }
 }
 
 /// Functions that mocks the posts query responses.
 pub fn mock_posts_query_response(query: &PostsQuery) -> ContractResult<Binary> {
     let response = match query {
         PostsQuery::SubspacePosts { subspace_id, .. } => to_binary(&QuerySubspacePostsResponse {
-            posts: get_mocked_subspace_posts(subspace_id),
+            posts: MockPostsQueries::get_mocked_subspace_posts(subspace_id),
             pagination: None,
         }),
         PostsQuery::SectionPosts {
@@ -156,7 +162,7 @@ pub fn mock_posts_query_response(query: &PostsQuery) -> ContractResult<Binary> {
             section_id,
             ..
         } => to_binary(&QuerySectionPostsResponse {
-            posts: get_mocked_section_posts(subspace_id, section_id),
+            posts: MockPostsQueries::get_mocked_section_posts(subspace_id, section_id),
             pagination: None,
         }),
         PostsQuery::Post {
@@ -164,14 +170,14 @@ pub fn mock_posts_query_response(query: &PostsQuery) -> ContractResult<Binary> {
             post_id,
             ..
         } => to_binary(&QueryPostResponse {
-            post: get_mocked_post(*subspace_id, *post_id),
+            post: MockPostsQueries::get_mocked_post(*subspace_id, *post_id),
         }),
         PostsQuery::PostAttachments {
             subspace_id,
             post_id,
             ..
         } => to_binary(&QueryPostAttachmentsResponse {
-            attachments: get_mocked_post_attachments(subspace_id, post_id),
+            attachments: MockPostsQueries::get_mocked_post_attachments(subspace_id, post_id),
             pagination: None,
         }),
         PostsQuery::PollAnswers {
@@ -181,7 +187,7 @@ pub fn mock_posts_query_response(query: &PostsQuery) -> ContractResult<Binary> {
             user,
             ..
         } => to_binary(&QueryPollAnswersResponse {
-            answers: get_mocked_poll_answers(subspace_id, post_id, poll_id, user),
+            answers: MockPostsQueries::get_mocked_poll_answers(subspace_id, post_id, poll_id, user),
             pagination: None,
         }),
     };

--- a/packages/bindings/src/posts/querier.rs
+++ b/packages/bindings/src/posts/querier.rs
@@ -279,7 +279,7 @@ impl<'a> PostsQuerier<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::mocks::mock_dependencies_with_custom_querier;
+    use crate::mocks::mock_queriers::mock_dependencies_with_custom_querier;
     use crate::posts::mocks::{
         get_mocked_poll_answers, get_mocked_post, get_mocked_post_attachments,
         get_mocked_section_posts, get_mocked_subspace_posts,

--- a/packages/bindings/src/posts/querier.rs
+++ b/packages/bindings/src/posts/querier.rs
@@ -280,10 +280,7 @@ impl<'a> PostsQuerier<'a> {
 #[cfg(test)]
 mod tests {
     use crate::mocks::mock_queriers::mock_dependencies_with_custom_querier;
-    use crate::posts::mocks::{
-        get_mocked_poll_answers, get_mocked_post, get_mocked_post_attachments,
-        get_mocked_section_posts, get_mocked_subspace_posts,
-    };
+    use crate::posts::mocks::MockPostsQueries;
     use crate::posts::querier::PostsQuerier;
     use cosmwasm_std::Uint64;
     use std::ops::Deref;
@@ -301,7 +298,7 @@ mod tests {
         assert_eq!(2, response.posts.len());
 
         let posts = response.posts;
-        assert_eq!(get_mocked_subspace_posts(&Uint64::zero()), posts);
+        assert_eq!(MockPostsQueries::get_mocked_subspace_posts(&Uint64::zero()), posts);
     }
 
     #[test]
@@ -311,7 +308,7 @@ mod tests {
         let querier = PostsQuerier::new(deps.querier.deref());
 
         let mut iterator = querier.iterate_subspace_posts(0, 32);
-        let expected_posts = get_mocked_subspace_posts(&Uint64::zero());
+        let expected_posts = MockPostsQueries::get_mocked_subspace_posts(&Uint64::zero());
 
         // The first item returned from the iterators should be the first item returned from the mock function.
         assert_eq!(
@@ -340,7 +337,7 @@ mod tests {
         assert_eq!(2, response.posts.len());
 
         let posts = response.posts;
-        assert_eq!(get_mocked_section_posts(&Uint64::zero(), &0), posts);
+        assert_eq!(MockPostsQueries::get_mocked_section_posts(&Uint64::zero(), &0), posts);
     }
 
     #[test]
@@ -350,7 +347,7 @@ mod tests {
         let querier = PostsQuerier::new(deps.querier.deref());
 
         let mut iterator = querier.iterate_section_posts(0, 0, 32);
-        let expected_posts = get_mocked_section_posts(&Uint64::zero(), &0);
+        let expected_posts = MockPostsQueries::get_mocked_section_posts(&Uint64::zero(), &0);
 
         // The first item returned from the iterators should be the first item returned from the mock function.
         assert_eq!(
@@ -373,7 +370,7 @@ mod tests {
         let querier = PostsQuerier::new(deps.querier.deref());
 
         let result = querier.query_post(0, 42);
-        let expected_post = get_mocked_post(Uint64::zero(), Uint64::new(42));
+        let expected_post = MockPostsQueries::get_mocked_post(Uint64::zero(), Uint64::new(42));
 
         assert_eq!(expected_post, result.unwrap().post);
     }
@@ -392,7 +389,7 @@ mod tests {
 
         let attachments = response.attachments;
         assert_eq!(
-            get_mocked_post_attachments(&Uint64::zero(), &Uint64::zero()),
+            MockPostsQueries::get_mocked_post_attachments(&Uint64::zero(), &Uint64::zero()),
             attachments
         );
     }
@@ -404,7 +401,7 @@ mod tests {
         let querier = PostsQuerier::new(deps.querier.deref());
 
         let mut iterator = querier.iterate_post_attachments(0, 0, 32);
-        let expected_attachments = get_mocked_post_attachments(&Uint64::zero(), &Uint64::zero());
+        let expected_attachments = MockPostsQueries::get_mocked_post_attachments(&Uint64::zero(), &Uint64::zero());
 
         // The first item returned from the iterators should be the first item returned from the mock function.
         assert_eq!(
@@ -434,7 +431,7 @@ mod tests {
 
         let answers = response.answers;
         assert_eq!(
-            get_mocked_poll_answers(&Uint64::zero(), &Uint64::zero(), &0, &None),
+            MockPostsQueries::get_mocked_poll_answers(&Uint64::zero(), &Uint64::zero(), &0, &None),
             answers
         );
     }
@@ -446,7 +443,7 @@ mod tests {
         let querier = PostsQuerier::new(deps.querier.deref());
 
         let mut iterator = querier.iterate_poll_answers(0, 0, 0, None, 32);
-        let expected_answers = get_mocked_poll_answers(&Uint64::zero(), &Uint64::zero(), &0, &None);
+        let expected_answers = MockPostsQueries::get_mocked_poll_answers(&Uint64::zero(), &Uint64::zero(), &0, &None);
 
         // The first item returned from the iterators should be the first item returned from the mock function.
         assert_eq!(

--- a/packages/bindings/src/profiles/querier.rs
+++ b/packages/bindings/src/profiles/querier.rs
@@ -377,7 +377,7 @@ impl<'a> ProfilesQuerier<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        mocks::mock_dependencies_with_custom_querier,
+        mocks::mock_queriers::mock_dependencies_with_custom_querier,
         profiles::{
             mocks::MockProfilesQueries,
             models_query::{

--- a/packages/bindings/src/reactions/querier.rs
+++ b/packages/bindings/src/reactions/querier.rs
@@ -216,7 +216,7 @@ impl<'a> ReactionsQuerier<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mocks::mock_dependencies_with_custom_querier;
+    use crate::mocks::mock_queriers::mock_dependencies_with_custom_querier;
     use crate::reactions::mocks::MockReactionsQueries;
     use std::ops::Deref;
 

--- a/packages/bindings/src/relationships/querier.rs
+++ b/packages/bindings/src/relationships/querier.rs
@@ -172,7 +172,7 @@ impl<'a> RelationshipsQuerier<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        mocks::mock_dependencies_with_custom_querier,
+        mocks::mock_queriers::mock_dependencies_with_custom_querier,
         relationships::{
             mocks::MockRelationshipsQueries,
             models_query::{QueryBlocksResponse, QueryRelationshipsResponse},

--- a/packages/bindings/src/reports/mocks.rs
+++ b/packages/bindings/src/reports/mocks.rs
@@ -7,9 +7,41 @@ use crate::reports::models_query::{
 use crate::reports::query::ReportsQuery;
 use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, Uint64};
 
-/// Functions that generate a mocked list of reports present in a subspace.
-pub fn get_mocked_reports(subspace_id: &Uint64) -> Vec<Report> {
-    vec![
+pub struct MockReportsQueries {}
+
+impl MockReportsQueries {
+    /// Functions that generate a mocked list of reports present in a subspace.
+    pub fn get_mocked_reports(subspace_id: &Uint64) -> Vec<Report> {
+        vec![
+            Report {
+                subspace_id: *subspace_id,
+                id: Uint64::new(0),
+                reasons_ids: vec![0, 2],
+                message: None,
+                reporter: Addr::unchecked("desmos1rfv0f7mx7w9d3jv3h803u38vqym9ygg344asm3"),
+                target: ReportTarget::User {
+                    user: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
+                }
+                .into(),
+                creation_date: "".to_string(),
+            },
+            Report {
+                subspace_id: *subspace_id,
+                id: Uint64::new(0),
+                reasons_ids: vec![],
+                message: Some("Report text".to_string()),
+                reporter: Addr::unchecked("desmos1rfv0f7mx7w9d3jv3h803u38vqym9ygg344asm3"),
+                target: ReportTarget::Post {
+                    post_id: Uint64::new(42),
+                }
+                .into(),
+                creation_date: "".to_string(),
+            },
+        ]
+    }
+
+    /// Functions that generate a mocked report present in a subspace.
+    pub fn get_mocked_report(subspace_id: &Uint64) -> Report {
         Report {
             subspace_id: *subspace_id,
             id: Uint64::new(0),
@@ -21,63 +53,35 @@ pub fn get_mocked_reports(subspace_id: &Uint64) -> Vec<Report> {
             }
             .into(),
             creation_date: "".to_string(),
-        },
-        Report {
-            subspace_id: *subspace_id,
-            id: Uint64::new(0),
-            reasons_ids: vec![],
-            message: Some("Report text".to_string()),
-            reporter: Addr::unchecked("desmos1rfv0f7mx7w9d3jv3h803u38vqym9ygg344asm3"),
-            target: ReportTarget::Post {
-                post_id: Uint64::new(42),
-            }
-            .into(),
-            creation_date: "".to_string(),
-        },
-    ]
-}
-
-/// Functions that generate a mocked report present in a subspace.
-pub fn get_mocked_report(subspace_id: &Uint64) -> Report {
-    Report {
-        subspace_id: *subspace_id,
-        id: Uint64::new(0),
-        reasons_ids: vec![0, 2],
-        message: None,
-        reporter: Addr::unchecked("desmos1rfv0f7mx7w9d3jv3h803u38vqym9ygg344asm3"),
-        target: ReportTarget::User {
-            user: Addr::unchecked("desmos1nwp8gxrnmrsrzjdhvk47vvmthzxjtphgxp5ftc"),
         }
-        .into(),
-        creation_date: "".to_string(),
     }
-}
 
-/// Functions that generate a mocked list of report reasons present in a subspace.
-pub fn get_mocked_reasons(subspace_id: &Uint64) -> Vec<Reason> {
-    vec![
+    /// Functions that generate a mocked list of report reasons present in a subspace.
+    pub fn get_mocked_reasons(subspace_id: &Uint64) -> Vec<Reason> {
+        vec![
+            Reason {
+                subspace_id: *subspace_id,
+                id: 1,
+                title: "Mock reason 1".to_string(),
+                description: None,
+            },
+            Reason {
+                subspace_id: *subspace_id,
+                id: 2,
+                title: "Mock reason 2".to_string(),
+                description: Some("Reason description".to_string()),
+            },
+        ]
+    }
+
+    /// Functions that generate a mocked report reason present in a subspace.
+    pub fn get_mocked_reason(subspace_id: &Uint64) -> Reason {
         Reason {
             subspace_id: *subspace_id,
             id: 1,
             title: "Mock reason 1".to_string(),
             description: None,
-        },
-        Reason {
-            subspace_id: *subspace_id,
-            id: 2,
-            title: "Mock reason 2".to_string(),
-            description: Some("Reason description".to_string()),
-        },
-    ]
-}
-
-/// Functions that generate a mocked report reason present in a subspace.
-pub fn get_mocked_reason(subspace_id: &Uint64) -> Reason {
-    Reason {
-        subspace_id: *subspace_id,
-        id: 1,
-        title: "Mock reason 1".to_string(),
-        description: None,
+        }
     }
 }
 
@@ -85,18 +89,18 @@ pub fn get_mocked_reason(subspace_id: &Uint64) -> Reason {
 pub fn mock_reports_query_response(query: &ReportsQuery) -> ContractResult<Binary> {
     let response = match query {
         ReportsQuery::Reports { subspace_id, .. } => to_binary(&QueryReportsResponse {
-            reports: get_mocked_reports(subspace_id),
+            reports: MockReportsQueries::get_mocked_reports(subspace_id),
             pagination: None,
         }),
         ReportsQuery::Report { subspace_id, .. } => to_binary(&QueryReportResponse {
-            report: get_mocked_report(subspace_id),
+            report: MockReportsQueries::get_mocked_report(subspace_id),
         }),
         ReportsQuery::Reasons { subspace_id, .. } => to_binary(&QueryReasonsResponse {
-            reasons: get_mocked_reasons(subspace_id),
+            reasons: MockReportsQueries::get_mocked_reasons(subspace_id),
             pagination: None,
         }),
         ReportsQuery::Reason { subspace_id, .. } => to_binary(&QueryReasonResponse {
-            reason: get_mocked_reason(subspace_id),
+            reason: MockReportsQueries::get_mocked_reason(subspace_id),
         }),
     };
     response.into()

--- a/packages/bindings/src/reports/mocks.rs
+++ b/packages/bindings/src/reports/mocks.rs
@@ -7,6 +7,8 @@ use crate::reports::models_query::{
 use crate::reports::query::ReportsQuery;
 use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, Uint64};
 
+/// Struct that contains some utility methods to mock data of the Desmos
+/// x/reports module.
 pub struct MockReportsQueries {}
 
 impl MockReportsQueries {

--- a/packages/bindings/src/reports/querier.rs
+++ b/packages/bindings/src/reports/querier.rs
@@ -182,10 +182,8 @@ impl<'a> ReportsQuerier<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::mocks::mock_dependencies_with_custom_querier;
-    use crate::reports::mocks::{
-        get_mocked_reason, get_mocked_reasons, get_mocked_report, get_mocked_reports,
-    };
+    use crate::mocks::mock_queriers::mock_dependencies_with_custom_querier;
+    use crate::reports::mocks::MockReportsQueries;
     use crate::reports::querier::ReportsQuerier;
     use cosmwasm_std::Uint64;
     use std::ops::Deref;
@@ -197,7 +195,7 @@ mod tests {
         let reports_querier = ReportsQuerier::new(deps.querier.deref());
 
         let response = reports_querier.query_reports(1, None, None, None).unwrap();
-        assert_eq!(get_mocked_reports(&Uint64::new(1)), response.reports);
+        assert_eq!(MockReportsQueries::get_mocked_reports(&Uint64::new(1)), response.reports);
         assert_eq!(None, response.pagination);
     }
 
@@ -208,7 +206,7 @@ mod tests {
         let reports_querier = ReportsQuerier::new(deps.querier.deref());
 
         let mut it = reports_querier.iterate_reports(1, None, None, 32);
-        let expected_items = get_mocked_reports(&Uint64::new(1));
+        let expected_items = MockReportsQueries::get_mocked_reports(&Uint64::new(1));
 
         let first_element = it.next().unwrap().unwrap();
         let second_element = it.next().unwrap().unwrap();
@@ -224,7 +222,7 @@ mod tests {
         let reports_querier = ReportsQuerier::new(deps.querier.deref());
 
         let response = reports_querier.query_report(1, 1).unwrap();
-        assert_eq!(get_mocked_report(&Uint64::new(1)), response.report);
+        assert_eq!(MockReportsQueries::get_mocked_report(&Uint64::new(1)), response.report);
     }
 
     #[test]
@@ -234,7 +232,7 @@ mod tests {
         let reports_querier = ReportsQuerier::new(deps.querier.deref());
 
         let response = reports_querier.query_reasons(1, None).unwrap();
-        assert_eq!(get_mocked_reasons(&Uint64::new(1)), response.reasons);
+        assert_eq!(MockReportsQueries::get_mocked_reasons(&Uint64::new(1)), response.reasons);
         assert_eq!(None, response.pagination);
     }
 
@@ -245,7 +243,7 @@ mod tests {
         let reports_querier = ReportsQuerier::new(deps.querier.deref());
 
         let mut it = reports_querier.iterate_reasons(1, 32);
-        let expected_items = get_mocked_reasons(&Uint64::new(1));
+        let expected_items = MockReportsQueries::get_mocked_reasons(&Uint64::new(1));
 
         let first_element = it.next().unwrap().unwrap();
         let second_element = it.next().unwrap().unwrap();
@@ -261,6 +259,6 @@ mod tests {
         let reports_querier = ReportsQuerier::new(deps.querier.deref());
 
         let response = reports_querier.query_reason(1, 1).unwrap();
-        assert_eq!(get_mocked_reason(&Uint64::new(1)), response.reason);
+        assert_eq!(MockReportsQueries::get_mocked_reason(&Uint64::new(1)), response.reason);
     }
 }

--- a/packages/bindings/src/subspaces/querier.rs
+++ b/packages/bindings/src/subspaces/querier.rs
@@ -307,7 +307,7 @@ impl<'a> SubspacesQuerier<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mocks::mock_dependencies_with_custom_querier;
+    use crate::mocks::mock_queriers::mock_dependencies_with_custom_querier;
     use crate::subspaces::mocks::MockSubspacesQueries;
     use std::ops::Deref;
 


### PR DESCRIPTION
This PR merges `test_utils` and `mocks` into a folder, then renaming to `mack_apps` and `mock_queriers`.
Besides, it also improves `x/posts` and `x/reports` to have `MockQueries` struct collecting all mock functions as other modules.