### PR TITLE
chore: release v1.0.1

### DIFF
--- a/.changeset/config.yaml
+++ b/.changeset/config.yaml
@@ -1,0 +1,55 @@
+github_repo: https://github.com/desmos-labs/desmos-bindings.git
+version: 1.0.1
+types:
+- code: fix
+  title: Bug Fixes
+  description: A bug fix
+  hide: false
+- code: deps
+  title: Dependencies
+  description: Updated a third party dependency
+  hide: false
+- code: docs
+  title: Documentation
+  description: Documentation only changes
+  hide: true
+- code: style
+  title: Styles
+  description: Changes that do not affect the meaning of the code (white-space, formatting,
+    missing semi-colons, etc)
+  hide: true
+- code: refactor
+  title: Code Refactoring
+  description: A code change that neither fixes a bug nor adds a feature
+  hide: true
+- code: test
+  title: Tests
+  description: Adding missing tests or correcting existing tests
+  hide: true
+- code: build
+  title: Builds
+  description: 'Changes that affect the build system or external dependencies (example
+    scopes: gulp, broccoli, npm)'
+  hide: true
+- code: feat
+  title: Features
+  description: A new feature
+  hide: false
+- code: revert
+  title: Reverts
+  description: Reverts a previous commit
+  hide: false
+- code: ci
+  title: Continuous Integrations
+  description: 'Changes to our CI configuration files and scripts (example scopes:
+    Travis, Circle, BrowserStack, SauceLabs)'
+  hide: true
+- code: chore
+  title: Chores
+  description: Other changes that don't modify src or test files
+  hide: true
+- code: perf
+  title: Performance Improvements
+  description: A code change that improves performance
+  hide: false
+modules: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,10 @@
 # Changelog
 
-## Unreleased
+## Version 1.0.1
 
-- Added `PageIterator` to provide paginated chain data as a sequence of elements;
-- Renamed package from `desmos-std` to `desmos-bindings`;
-- Added methods to queriers to fetch data using the `PageIterator`;
-- 
+* (#29)[https://github.com/desmos-labs/desmos-bindings/pull/29] Added integration test library `mock_apps`
+* (#30)[https://github.com/desmos-labs/desmos-bindings/pull/30] Replace `mocks` feature into `test` config
 
-### Version 0.1.6
+## Version 1.0.0
 
-- Renamed package from `desmos-cw` to `desmos-std`
-
-### Version 0.1.4
-
-- Renamed package from `desmos` to `desmos-cw`
-
-### Version 0.1.3
-
-- Updated `cosmwasm` dependencies to `v1.0.0-beta`;
-- Updated custom queries code to fit `v1.0.0-beta` changes;
-- Updated schemas;
-- Fixed broken tests.
-
-### Version 0.1.2
-
-- Updated `cosmwasm` to `v0.14.0`;
-- Updated schemas to be compatible the latest [desmos](https://github.com/desmos-labs/desmos) version changes;
-- Fixed broken tests.
+* Implemented all modules for cosmwasm 


### PR DESCRIPTION
This PR releases v1.0.1 in order to include testing mocks module. 
It also initializes the `changeset`.