### PR TITLE
fix: fixed mocks cfg tags

### DIFF
--- a/.changeset/entries/4abbb9307cae54efc52136196cd3136e8e2839fdd6463751be3a3b1033a1449c.yaml
+++ b/.changeset/entries/4abbb9307cae54efc52136196cd3136e8e2839fdd6463751be3a3b1033a1449c.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: none
+pull_request: 37
+description: Fixed mocks cfg tags
+backward_compatible: true
+date: 2022-08-08T09:54:08.4074112Z

--- a/.github/workflows/desmos_bindings.yml
+++ b/.github/workflows/desmos_bindings.yml
@@ -69,11 +69,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo fmt
-        working-directory: ./packages/bindings
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        working-directory: ./packages/bindings
         run: cargo clippy
 
   build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "desmos-bindings"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desmos-bindings"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
     "Leonardo Bragagnolo <leonardo@forbole.com>",
     "Paul Chen <paul@forbole.com>",

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate core;
 #[cfg(feature = "iterators")]
 pub mod iter;
-#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 #[cfg(feature = "msg")]
 pub mod msg;

--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate core;
 #[cfg(feature = "iterators")]
 pub mod iter;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
 pub mod mocks;
 #[cfg(feature = "msg")]
 pub mod msg;

--- a/packages/bindings/src/mocks/mock_queriers.rs
+++ b/packages/bindings/src/mocks/mock_queriers.rs
@@ -15,7 +15,7 @@ use crate::reports::mocks::mock_reports_query_response;
 use crate::subspaces::mocks::mock_subspaces_query_response;
 use cosmwasm_std::{
     testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
-    Coin, CustomQuery, OwnedDeps, SystemError, SystemResult,
+    Coin, OwnedDeps, SystemError, SystemResult,
 };
 use std::marker::PhantomData;
 

--- a/packages/bindings/src/posts/mod.rs
+++ b/packages/bindings/src/posts/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/posts module.
 
-#[cfg(all(not(target_arch = "wasm32"), test))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 pub mod models;
 #[cfg(feature = "query")]

--- a/packages/bindings/src/posts/mod.rs
+++ b/packages/bindings/src/posts/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/posts module.
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
 pub mod mocks;
 pub mod models;
 #[cfg(feature = "query")]

--- a/packages/bindings/src/reactions/mod.rs
+++ b/packages/bindings/src/reactions/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/reactions module.
 
-#[cfg(all(not(target_arch = "wasm32"), test))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 
 pub mod models;

--- a/packages/bindings/src/reactions/mod.rs
+++ b/packages/bindings/src/reactions/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/reactions module.
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
 pub mod mocks;
 
 pub mod models;

--- a/packages/bindings/src/relationships/mod.rs
+++ b/packages/bindings/src/relationships/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/relationships module.
 
-#[cfg(all(not(target_arch = "wasm32"), test))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 
 pub mod models;

--- a/packages/bindings/src/relationships/mod.rs
+++ b/packages/bindings/src/relationships/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/relationships module.
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
 pub mod mocks;
 
 pub mod models;

--- a/packages/bindings/src/reports/mod.rs
+++ b/packages/bindings/src/reports/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/reports module.
 
-#[cfg(all(not(target_arch = "wasm32"), test))]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 pub mod models;
 #[cfg(feature = "query")]

--- a/packages/bindings/src/reports/mod.rs
+++ b/packages/bindings/src/reports/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities,structs and enum to interact with the Desmos x/reports module.
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "mocks"))]
 pub mod mocks;
 pub mod models;
 #[cfg(feature = "query")]


### PR DESCRIPTION
This PR fixes the cfg tags to prevent the error with `cargo clippy` command.