### PR TITLE
ci: dependabot and mergify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - bragaz
+      - dadamu
+      - manu0466
+    labels:
+      - automerge
+      - dependencies

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,18 @@
+queue_rules:
+  - name: default
+    conditions:
+      - base=main
+
+pull_request_rules:
+  - name: automerge to master with label automerge and branch protection passing
+    conditions:
+      - "#approved-reviews-by>1"
+      - label=automerge
+    actions:
+      queue:
+        name: default
+        method: squash
+        commit_message_template: >
+          {{ title }} (#{{ number }})
+          
+          {{ body }}


### PR DESCRIPTION
Added dependabot to keep the project dependencies updated and mergify to automatically merge a PR with the label `automerge`