### PR TITLE
ci: reduced test chain block time to reduce ci execution time

### DIFF
--- a/.github/workflows/chain_interaction.yml
+++ b/.github/workflows/chain_interaction.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: ./packages/bindings-test
         run: | 
           ../../desmos/spawn_test_chain.sh -b
-          sleep 10 
+          sleep 2 
           ../../desmos/setup_chain.sh
           cargo test --all-features -- --test-threads=1
 

--- a/desmos/spawn_test_chain.sh
+++ b/desmos/spawn_test_chain.sh
@@ -30,9 +30,15 @@ desmos() {
 rm -r -f "$DESMOS_HOME"
 desmos tendermint unsafe-reset-all
 desmos init testchain --chain-id=testchain
+
 # Add a default reason to the reports module params
-jq '.app_state.reports.params.standard_reasons[0] |= . + {"id":"1","title":"Spam","description":"Spam user or content"}' "$DESMOS_HOME/config/genesis.json" > "$DESMOS_HOME/config/genesis-patched.json"
-mv "$DESMOS_HOME/config/genesis-patched.json" "$DESMOS_HOME/config/genesis.json"
+DESMOS_GENESIS="$DESMOS_HOME/config/genesis.json"
+jq '.app_state.reports.params.standard_reasons[0] |= . + {"id":"1","title":"Spam","description":"Spam user or content"}' \
+  "$DESMOS_GENESIS" > "$DESMOS_GENESIS.temp"
+mv "$DESMOS_GENESIS.temp" "$DESMOS_GENESIS"
+
+# Set block time to 500 milliseconds
+sed -i -e 's/timeout_commit = "5s"/timeout_commit = "500ms"/g' "$DESMOS_HOME/config/config.toml"
 
 (echo "$USER1_MNEMONIC"; echo $KEYRING_PASS; echo $KEYRING_PASS) | desmos keys add "$USER1" --recover --keyring-backend=file
 (echo "$USER2_MNEMONIC"; echo $KEYRING_PASS; echo $KEYRING_PASS) | desmos keys add "$USER2" --recover --keyring-backend=file


### PR DESCRIPTION
This PR aims to reduce the execution time of the `chain_interaction` workflow. 
The idea is to reduce the block time of the spawned test chain in order to reduce the overall ci execution time.