### PR TITLE
fix: fix missing feature in mock

### DIFF
--- a/.github/workflows/desmos_bindings.yml
+++ b/.github/workflows/desmos_bindings.yml
@@ -253,3 +253,8 @@ jobs:
         if: env.GIT_DIFF
         working-directory: ./packages/bindings
         run: cargo build --no-default-features --features msg,reports
+      
+      - name: Build feature (mocks) 🧪
+        if: env.GIT_DIFF
+        working-directory: ./packages/bindings
+        run: cargo build --no-default-features --features mocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.1
+## Bug Fixes
+- ([\#68](https://github.com/desmos-labs/desmos-bindings.git/pull/68)) Added missing features tags to `MockDesmosQuerier`
+
 ## Version 1.1.0
 ### Bug Fixes
 - ([\#37](https://github.com/desmos-labs/desmos-bindings.git/pull/37)) Fixed mocks cfg tags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "desmos-bindings"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below the compatibility between the bindings and the Desmos chain
 
 | Bindings Version | Desmos Version |
 |---|---|
-| **v1.1.0** | **v4.3.0** |
+| **v1.1.x** | **v4.3.0** |
 | **v1.0.0** | **v4.1.0** |
 
 # Create a new contract

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desmos-bindings"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     "Leonardo Bragagnolo <leonardo@forbole.com>",
     "Paul Chen <paul@forbole.com>",

--- a/packages/bindings/src/mocks/mock_queriers.rs
+++ b/packages/bindings/src/mocks/mock_queriers.rs
@@ -50,13 +50,19 @@ impl MockDesmosQuerier {
     pub fn new(balances: &[(&str, &[Coin])]) -> Self {
         MockDesmosQuerier {
             mock_querier: MockQuerier::new(balances),
+            #[cfg(feature = "profiles")]
             profiles_handler: Box::new(|q| SystemResult::Ok(mock_profiles_query_response(q))),
+            #[cfg(feature = "subspaces")]
             subspaces_handler: Box::new(|q| SystemResult::Ok(mock_subspaces_query_response(q))),
+            #[cfg(feature = "posts")]
             posts_handler: Box::new(|q| SystemResult::Ok(mock_posts_query_response(q))),
+            #[cfg(feature = "relationships")]
             relationships_handler: Box::new(|q| {
                 SystemResult::Ok(mock_relationships_query_response(q))
             }),
+            #[cfg(feature = "reports")]
             reports_handler: Box::new(|q| SystemResult::Ok(mock_reports_query_response(q))),
+            #[cfg(feature = "reactions")]
             reactions_handler: Box::new(|q| SystemResult::Ok(mock_reactions_query_response(q))),
         }
     }


### PR DESCRIPTION
This PR fixes the bug by adding missing features cfg to `MockDesmosQuerier`. After it merges, it would be new version 1.1.1.