### PR TITLE
fix: post model `external_id` field

### DIFF
--- a/packages/bindings-test/src/posts/query.rs
+++ b/packages/bindings-test/src/posts/query.rs
@@ -20,7 +20,7 @@ mod test {
             id: TEST_SUBSPACE_EDITABLE_POST_ID,
             subspace_id: TEST_SUBSPACE,
             section_id: 0,
-            eternal_id: None,
+            external_id: None,
             text: Some("Editable post".to_string()),
             entities: Some(Entities {
                 hashtags: vec![],
@@ -49,7 +49,7 @@ mod test {
         assert_eq!(post_l.id, post_r.id);
         assert_eq!(post_l.subspace_id, post_r.subspace_id);
         assert_eq!(post_l.section_id, post_r.section_id);
-        assert_eq!(post_l.eternal_id, post_r.eternal_id);
+        assert_eq!(post_l.external_id, post_r.external_id);
         assert_eq!(post_l.text, post_r.text);
         assert_eq!(post_l.entities, post_r.entities);
         assert_eq!(post_l.author, post_r.author);

--- a/packages/bindings/src/posts/mocks.rs
+++ b/packages/bindings/src/posts/mocks.rs
@@ -19,7 +19,7 @@ impl MockPostsQueries {
             Post {
                 subspace_id: *subspace_id,
                 section_id: 0,
-                eternal_id: None,
+                external_id: None,
                 text: None,
                 entities: None,
                 tags: vec![],
@@ -34,7 +34,7 @@ impl MockPostsQueries {
             Post {
                 subspace_id: *subspace_id,
                 section_id: 0,
-                eternal_id: None,
+                external_id: None,
                 text: None,
                 entities: None,
                 tags: vec![],
@@ -55,7 +55,7 @@ impl MockPostsQueries {
             Post {
                 subspace_id: *subspace_id,
                 section_id: *section_id,
-                eternal_id: None,
+                external_id: None,
                 text: None,
                 entities: None,
                 tags: vec![],
@@ -70,7 +70,7 @@ impl MockPostsQueries {
             Post {
                 subspace_id: *subspace_id,
                 section_id: *section_id,
-                eternal_id: None,
+                external_id: None,
                 text: None,
                 entities: None,
                 tags: vec![],
@@ -91,7 +91,7 @@ impl MockPostsQueries {
             id: post_id,
             subspace_id,
             section_id: 0,
-            eternal_id: None,
+            external_id: None,
             text: None,
             entities: None,
             tags: vec![],

--- a/packages/bindings/src/posts/models.rs
+++ b/packages/bindings/src/posts/models.rs
@@ -23,7 +23,7 @@ pub struct Post {
     /// Id of the section inside which the post has been created.
     pub section_id: u32,
     /// External id for this post.
-    pub eternal_id: Option<String>,
+    pub external_id: Option<String>,
     /// Text of the post.
     pub text: Option<String>,
     /// Entities connected to this post.


### PR DESCRIPTION
Currently the Post model has the `external_id` field named `eternal_id` instead of `external_id`, this PR fixes this.