### PR TITLE
feat: allow to customize query respone in integration tests

### DIFF
--- a/packages/bindings/src/mocks/mock_keeper.rs
+++ b/packages/bindings/src/mocks/mock_keeper.rs
@@ -605,6 +605,17 @@ impl Module for DesmosKeeper {
         }
     }
 
+    fn sudo<ExecC, QueryC>(
+        &self,
+        _api: &dyn Api,
+        _storage: &mut dyn Storage,
+        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
+        _block: &BlockInfo,
+        _msg: Empty,
+    ) -> AnyResult<AppResponse> {
+        unimplemented!()
+    }
+
     fn query(
         &self,
         _api: &dyn Api,
@@ -625,16 +636,5 @@ impl Module for DesmosKeeper {
                 ContractResult::Err(err) => AnyResult::Err(anyhow::Error::msg(err)),
             }
         }
-    }
-
-    fn sudo<ExecC, QueryC>(
-        &self,
-        _api: &dyn Api,
-        _storage: &mut dyn Storage,
-        _router: &dyn CosmosRouter<ExecC = ExecC, QueryC = QueryC>,
-        _block: &BlockInfo,
-        _msg: Empty,
-    ) -> AnyResult<AppResponse> {
-        unimplemented!()
     }
 }

--- a/packages/bindings/src/mocks/mock_keeper.rs
+++ b/packages/bindings/src/mocks/mock_keeper.rs
@@ -1,64 +1,73 @@
+//! Contains integration test utils to mock the responses that a contract receive
+//! when performing integration tests.
+
 #![cfg(not(tarpaulin_include))]
+use crate::mocks::mock_queriers::MockDesmosQuerier;
 use crate::msg::DesmosMsg;
+#[cfg(feature = "posts")]
+use crate::posts::msg::PostsMsg;
+#[cfg(feature = "profiles")]
+use crate::profiles::msg::ProfilesMsg;
 use crate::query::DesmosQuery;
+#[cfg(feature = "reactions")]
+use crate::reactions::msg::ReactionsMsg;
+#[cfg(feature = "relationships")]
+use crate::relationships::msg::RelationshipsMsg;
+#[cfg(feature = "reports")]
+use crate::reports::{models::ReportTarget, msg::ReportsMsg};
+#[cfg(feature = "subspaces")]
+use crate::subspaces::msg::SubspacesMsg;
 use anyhow::Result as AnyResult;
-use cosmwasm_std::{Addr, Api, Binary, BlockInfo, Empty, Event, Querier, Storage};
+use cosmwasm_std::{
+    Addr, Api, Binary, BlockInfo, ContractResult, Empty, Event, Querier, QueryRequest, Storage,
+};
 use cw_multi_test::{AppResponse, CosmosRouter, Module};
 use std::convert::TryFrom;
 
-#[cfg(feature = "posts")]
-use crate::posts::{mocks::mock_posts_query_response, msg::PostsMsg};
-#[cfg(feature = "profiles")]
-use crate::profiles::{mocks::mock_profiles_query_response, msg::ProfilesMsg};
-#[cfg(feature = "reactions")]
-use crate::reactions::{mocks::mock_reactions_query_response, msg::ReactionsMsg};
-#[cfg(feature = "relationships")]
-use crate::relationships::{mocks::mock_relationships_query_response, msg::RelationshipsMsg};
-#[cfg(feature = "reports")]
-use crate::reports::{mocks::mock_reports_query_response, models::ReportTarget, msg::ReportsMsg};
-#[cfg(feature = "subspaces")]
-use crate::subspaces::{mocks::mock_subspaces_query_response, msg::SubspacesMsg};
-
 /// Represents the implementation of [`Module`](cw_multi_test::Module) for handling the desmos execution and query messages.
 #[derive(Default)]
-pub struct DesmosKeeper {}
+pub struct DesmosKeeper {
+    /// Querier used to handle the query requests.
+    pub querier: MockDesmosQuerier,
+}
 
 impl DesmosKeeper {
     /// Returns a new [DesmosKeeper].
     pub fn new() -> Self {
-        DesmosKeeper {}
+        DesmosKeeper {
+            querier: MockDesmosQuerier::new(&[]),
+        }
     }
 
-    /// Handles [`ProfilesMsg`](crate::profiles::ProfilesMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/profiles/spec/05-events.md).
+    /// Returns a new [DesmosKeeper] with a custom instance of [MockDesmosQuerier].
+    pub fn with_custom_querier(querier: MockDesmosQuerier) -> Self {
+        DesmosKeeper { querier }
+    }
+
+    /// Handles [`ProfilesMsg`](crate::profiles::msg::ProfilesMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/profiles/spec/05-events.md).
     #[cfg(feature = "profiles")]
-    fn handle_profiles_msg(&self, block: &BlockInfo, msg: ProfilesMsg) -> AnyResult<AppResponse> {
+    pub fn handle_profiles_msg(block: &BlockInfo, msg: ProfilesMsg) -> AnyResult<AppResponse> {
         match msg {
             ProfilesMsg::SaveProfile { dtag, creator, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("save_profile")
-                        .add_attribute("profile_dtag", dtag)
-                        .add_attribute("profile_creator", creator)
-                        .add_attribute("profile_creation_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("save_profile")
+                    .add_attribute("profile_dtag", dtag)
+                    .add_attribute("profile_creator", creator)
+                    .add_attribute("profile_creation_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::DeleteProfile { creator, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(Event::new("delete_profile").add_attribute("profile_creator", creator));
+                let events =
+                    vec![Event::new("delete_profile").add_attribute("profile_creator", creator)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::RequestDtagTransfer {
                 sender: request_sender,
                 receiver: request_receiver,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_dtag_transfer_request")
-                        .add_attribute("dtag_to_trade", "test")
-                        .add_attribute("request_sender", request_sender)
-                        .add_attribute("request_receiver", request_receiver),
-                );
+                let events = vec![Event::new("create_dtag_transfer_request")
+                    .add_attribute("dtag_to_trade", "test")
+                    .add_attribute("request_sender", request_sender)
+                    .add_attribute("request_receiver", request_receiver)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::AcceptDtagTransferRequest {
@@ -66,38 +75,29 @@ impl DesmosKeeper {
                 sender: request_sender,
                 receiver: request_receiver,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("accept_dtag_transfer_request")
-                        .add_attribute("dtag_to_trade", "test")
-                        .add_attribute("new_dtag", new_dtag)
-                        .add_attribute("request_sender", request_sender)
-                        .add_attribute("request_receiver", request_receiver),
-                );
+                let events = vec![Event::new("accept_dtag_transfer_request")
+                    .add_attribute("dtag_to_trade", "test")
+                    .add_attribute("new_dtag", new_dtag)
+                    .add_attribute("request_sender", request_sender)
+                    .add_attribute("request_receiver", request_receiver)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::RefuseDtagTransferRequest {
                 sender: request_sender,
                 receiver: request_receiver,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("refuse_dtag_transfer_request")
-                        .add_attribute("request_sender", request_sender)
-                        .add_attribute("request_receiver", request_receiver),
-                );
+                let events = vec![Event::new("refuse_dtag_transfer_request")
+                    .add_attribute("request_sender", request_sender)
+                    .add_attribute("request_receiver", request_receiver)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::CancelDtagTransferRequest {
                 sender: request_sender,
                 receiver: request_receiver,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("cancel_dtag_transfer_request")
-                        .add_attribute("request_sender", request_sender)
-                        .add_attribute("request_receiver", request_receiver),
-                );
+                let events = vec![Event::new("cancel_dtag_transfer_request")
+                    .add_attribute("request_sender", request_sender)
+                    .add_attribute("request_receiver", request_receiver)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::LinkChainAccount {
@@ -106,14 +106,11 @@ impl DesmosKeeper {
                 signer: owner,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("link_chain_account")
-                        .add_attribute("chain_link_account_target", chain_address.value)
-                        .add_attribute("chain_link_source_chain_name", chain_config.name)
-                        .add_attribute("chain_link_account_owner", owner)
-                        .add_attribute("chain_link_creation_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("link_chain_account")
+                    .add_attribute("chain_link_account_target", chain_address.value)
+                    .add_attribute("chain_link_source_chain_name", chain_config.name)
+                    .add_attribute("chain_link_account_owner", owner)
+                    .add_attribute("chain_link_creation_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::UnlinkChainAccount {
@@ -121,13 +118,10 @@ impl DesmosKeeper {
                 chain_name,
                 target,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("unlink_chain_account")
-                        .add_attribute("chain_link_account_target", target)
-                        .add_attribute("chain_link_source_chain_name", chain_name)
-                        .add_attribute("chain_link_account_owner", owner),
-                );
+                let events = vec![Event::new("unlink_chain_account")
+                    .add_attribute("chain_link_account_target", target)
+                    .add_attribute("chain_link_source_chain_name", chain_name)
+                    .add_attribute("chain_link_account_owner", owner)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::SetDefaultExternalAddress {
@@ -135,31 +129,22 @@ impl DesmosKeeper {
                 target,
                 signer,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("set_default_external_address")
-                        .add_attribute("chain_link_source_chain_name", chain_name)
-                        .add_attribute("chain_link_account_target", target)
-                        .add_attribute("chain_link_account_owner", signer),
-                );
-                AnyResult::Ok(AppResponse {
-                    events: events,
-                    data: None,
-                })
+                let events = vec![Event::new("set_default_external_address")
+                    .add_attribute("chain_link_source_chain_name", chain_name)
+                    .add_attribute("chain_link_account_target", target)
+                    .add_attribute("chain_link_account_owner", signer)];
+                AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::LinkApplication {
                 sender: user,
                 link_data,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("link_application")
-                        .add_attribute("user", user)
-                        .add_attribute("application_name", link_data.application)
-                        .add_attribute("application_username", link_data.username)
-                        .add_attribute("application_link_creation_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("link_application")
+                    .add_attribute("user", user)
+                    .add_attribute("application_name", link_data.application)
+                    .add_attribute("application_username", link_data.username)
+                    .add_attribute("application_link_creation_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ProfilesMsg::UnlinkApplication {
@@ -167,53 +152,41 @@ impl DesmosKeeper {
                 username,
                 signer: user,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("unlink_application")
-                        .add_attribute("user", user)
-                        .add_attribute("application_name", application)
-                        .add_attribute("application_username", username),
-                );
+                let events = vec![Event::new("unlink_application")
+                    .add_attribute("user", user)
+                    .add_attribute("application_name", application)
+                    .add_attribute("application_username", username)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
         }
     }
 
-    /// Handles [`SubspacesMsg`](crate::subspaces::SubspacesMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/subspaces/spec/05-events.md).
+    /// Handles [`SubspacesMsg`](crate::subspaces::msg::SubspacesMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/subspaces/spec/05-events.md).
     #[cfg(feature = "subspaces")]
-    fn handle_subspaces_msg(&self, block: &BlockInfo, msg: SubspacesMsg) -> AnyResult<AppResponse> {
+    pub fn handle_subspaces_msg(block: &BlockInfo, msg: SubspacesMsg) -> AnyResult<AppResponse> {
         match msg {
             SubspacesMsg::CreateSubspace { name, creator, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_subspace")
-                        .add_attribute("subspace_id", 1.to_string())
-                        .add_attribute("subspace_name", name)
-                        .add_attribute("subspace_creator", creator)
-                        .add_attribute("creation_date", block.time.to_string()),
-                );
+                let events = vec![Event::new("create_subspace")
+                    .add_attribute("subspace_id", 1.to_string())
+                    .add_attribute("subspace_name", name)
+                    .add_attribute("subspace_creator", creator)
+                    .add_attribute("creation_date", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::EditSubspace { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-
-                events.push(Event::new("edit_subspace").add_attribute("subspace_id", subspace_id));
+                let events =
+                    vec![Event::new("edit_subspace").add_attribute("subspace_id", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::DeleteSubspace { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-
-                events
-                    .push(Event::new("delete_subspace").add_attribute("subspace_id", subspace_id));
+                let events =
+                    vec![Event::new("delete_subspace").add_attribute("subspace_id", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::CreateSection { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_section")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("create_section", 1.to_string()),
-                );
+                let events = vec![Event::new("create_section")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("create_section", 1.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::EditSection {
@@ -221,12 +194,9 @@ impl DesmosKeeper {
                 section_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("edit_section")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("section_id", section_id.to_string()),
-                );
+                let events = vec![Event::new("edit_section")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("section_id", section_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::MoveSection {
@@ -234,12 +204,9 @@ impl DesmosKeeper {
                 section_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("move_section")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("section_id", section_id.to_string()),
-                );
+                let events = vec![Event::new("move_section")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("section_id", section_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::DeleteSection {
@@ -247,21 +214,15 @@ impl DesmosKeeper {
                 section_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("delete_section")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("section_id", section_id.to_string()),
-                );
+                let events = vec![Event::new("delete_section")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("section_id", section_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::CreateUserGroup { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_user_group")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", 1.to_string()),
-                );
+                let events = vec![Event::new("create_user_group")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", 1.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::EditUserGroup {
@@ -269,12 +230,9 @@ impl DesmosKeeper {
                 group_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("edit_user_group")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", group_id.to_string()),
-                );
+                let events = vec![Event::new("edit_user_group")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", group_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::MoveUserGroup {
@@ -282,12 +240,9 @@ impl DesmosKeeper {
                 group_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("move_user_group")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", group_id.to_string()),
-                );
+                let events = vec![Event::new("move_user_group")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", group_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::SetUserGroupPermissions {
@@ -295,12 +250,9 @@ impl DesmosKeeper {
                 group_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("set_user_group_permissions")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", group_id.to_string()),
-                );
+                let events = vec![Event::new("set_user_group_permissions")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", group_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::DeleteUserGroup {
@@ -308,12 +260,9 @@ impl DesmosKeeper {
                 group_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("delete_user_group")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", group_id.to_string()),
-                );
+                let events = vec![Event::new("delete_user_group")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", group_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::AddUserToUserGroup {
@@ -322,13 +271,10 @@ impl DesmosKeeper {
                 user,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("add_group_member")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", group_id.to_string())
-                        .add_attribute("user", user),
-                );
+                let events = vec![Event::new("add_group_member")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", group_id.to_string())
+                    .add_attribute("user", user)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::RemoveUserFromUserGroup {
@@ -337,45 +283,39 @@ impl DesmosKeeper {
                 user,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("remove_group_member")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user_group_id", group_id.to_string())
-                        .add_attribute("user", user),
-                );
+                let events = vec![Event::new("remove_group_member")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user_group_id", group_id.to_string())
+                    .add_attribute("user", user)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             SubspacesMsg::SetUserPermissions {
                 subspace_id, user, ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("set_user_permissions")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("user", user),
-                );
+                let events = vec![Event::new("set_user_permissions")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("user", user)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
         }
     }
 
-    /// Handles [`RelationshipsMsg`](crate::relationships::RelationshipsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/relationships/spec/05-events.md).
+    /// Handles [`RelationshipsMsg`](crate::relationships::msg::RelationshipsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/relationships/spec/05-events.md).
     #[cfg(feature = "relationships")]
-    fn handle_relationships_msg(&self, msg: RelationshipsMsg) -> AnyResult<AppResponse> {
+    pub fn handle_relationships_msg(
+        _block: &BlockInfo,
+        msg: RelationshipsMsg,
+    ) -> AnyResult<AppResponse> {
         match msg {
             RelationshipsMsg::CreateRelationship {
                 signer: creator,
                 counterparty,
                 subspace_id,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_relationship")
-                        .add_attribute("creator", creator)
-                        .add_attribute("counterparty", counterparty)
-                        .add_attribute("subspace", subspace_id),
-                );
+                let events = vec![Event::new("create_relationship")
+                    .add_attribute("creator", creator)
+                    .add_attribute("counterparty", counterparty)
+                    .add_attribute("subspace", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             RelationshipsMsg::DeleteRelationship {
@@ -383,13 +323,10 @@ impl DesmosKeeper {
                 counterparty,
                 subspace_id,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("delete_relationship")
-                        .add_attribute("creator", creator)
-                        .add_attribute("counterparty", counterparty)
-                        .add_attribute("subspace", subspace_id),
-                );
+                let events = vec![Event::new("delete_relationship")
+                    .add_attribute("creator", creator)
+                    .add_attribute("counterparty", counterparty)
+                    .add_attribute("subspace", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             RelationshipsMsg::BlockUser {
@@ -398,13 +335,10 @@ impl DesmosKeeper {
                 subspace_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("block_user")
-                        .add_attribute("blocker", blocker)
-                        .add_attribute("blocked", blocked)
-                        .add_attribute("subspace", subspace_id),
-                );
+                let events = vec![Event::new("block_user")
+                    .add_attribute("blocker", blocker)
+                    .add_attribute("blocked", blocked)
+                    .add_attribute("subspace", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             RelationshipsMsg::UnblockUser {
@@ -412,21 +346,18 @@ impl DesmosKeeper {
                 blocked,
                 subspace_id,
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_dtag_transfer_request")
-                        .add_attribute("blocker", blocker)
-                        .add_attribute("blocked", blocked)
-                        .add_attribute("subspace", subspace_id),
-                );
+                let events = vec![Event::new("create_dtag_transfer_request")
+                    .add_attribute("blocker", blocker)
+                    .add_attribute("blocked", blocked)
+                    .add_attribute("subspace", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
         }
     }
 
-    /// Handles [`PostsMsg`](crate::posts::PostsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/posts/spec/05-events.md).
+    /// Handles [`PostsMsg`](crate::posts::msg::PostsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/posts/spec/05-events.md).
     #[cfg(feature = "posts")]
-    fn handle_posts_msg(&self, block: &BlockInfo, msg: PostsMsg) -> AnyResult<AppResponse> {
+    pub fn handle_posts_msg(block: &BlockInfo, msg: PostsMsg) -> AnyResult<AppResponse> {
         match msg {
             PostsMsg::CreatePost {
                 subspace_id,
@@ -434,15 +365,12 @@ impl DesmosKeeper {
                 author,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_post")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("section_id", section_id.to_string())
-                        .add_attribute("post_id", 1.to_string())
-                        .add_attribute("author", author)
-                        .add_attribute("creation_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("create_post")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("section_id", section_id.to_string())
+                    .add_attribute("post_id", 1.to_string())
+                    .add_attribute("author", author)
+                    .add_attribute("creation_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             PostsMsg::EditPost {
@@ -450,13 +378,10 @@ impl DesmosKeeper {
                 post_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("edit_post")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id", post_id)
-                        .add_attribute("last_edit_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("edit_post")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id", post_id)
+                    .add_attribute("last_edit_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             PostsMsg::DeletePost {
@@ -464,12 +389,9 @@ impl DesmosKeeper {
                 post_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("delete_post")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id", post_id),
-                );
+                let events = vec![Event::new("delete_post")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id", post_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             PostsMsg::AddPostAttachment {
@@ -477,14 +399,11 @@ impl DesmosKeeper {
                 post_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("add_post_attachment")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id", post_id)
-                        .add_attribute("attachment_id", 1.to_string())
-                        .add_attribute("last_edit_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("add_post_attachment")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id", post_id)
+                    .add_attribute("attachment_id", 1.to_string())
+                    .add_attribute("last_edit_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             PostsMsg::RemovePostAttachment {
@@ -493,14 +412,11 @@ impl DesmosKeeper {
                 attachment_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("remove_post_attachment")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id", post_id)
-                        .add_attribute("attachment_id", attachment_id.to_string())
-                        .add_attribute("last_edit_time", block.time.to_string()),
-                );
+                let events = vec![Event::new("remove_post_attachment")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id", post_id)
+                    .add_attribute("attachment_id", attachment_id.to_string())
+                    .add_attribute("last_edit_time", block.time.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             PostsMsg::AnswerPoll {
@@ -509,21 +425,18 @@ impl DesmosKeeper {
                 poll_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("answer_poll")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id", post_id)
-                        .add_attribute("poll_id", poll_id.to_string()),
-                );
+                let events = vec![Event::new("answer_poll")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id", post_id)
+                    .add_attribute("poll_id", poll_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
         }
     }
 
-    /// Handles [`ReportsMsg`](crate::reports::ReportsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/reports/spec/05-events.md).
+    /// Handles [`ReportsMsg`](crate::reports::msg::ReportsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/reports/spec/05-events.md).
     #[cfg(feature = "reports")]
-    fn handle_reports_msg(&self, block: &BlockInfo, msg: ReportsMsg) -> AnyResult<AppResponse> {
+    pub fn handle_reports_msg(block: &BlockInfo, msg: ReportsMsg) -> AnyResult<AppResponse> {
         match msg {
             ReportsMsg::CreateReport {
                 subspace_id,
@@ -531,14 +444,11 @@ impl DesmosKeeper {
                 target,
                 ..
             } => {
-                let mut events = Vec::with_capacity(2);
-                events.push(
-                    Event::new("create_report")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("report_id", 1.to_string())
-                        .add_attribute("reporter", &reporter)
-                        .add_attribute("creation_time", block.time.to_string()),
-                );
+                let mut events = vec![Event::new("create_report")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("report_id", 1.to_string())
+                    .add_attribute("reporter", &reporter)
+                    .add_attribute("creation_time", block.time.to_string())];
                 let report_target = ReportTarget::try_from(target)?;
                 match report_target {
                     ReportTarget::Post { post_id } => {
@@ -565,12 +475,9 @@ impl DesmosKeeper {
                 report_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("delete_report")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("report_id", report_id),
-                );
+                let events = vec![Event::new("delete_report")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("report_id", report_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReportsMsg::SupportStandardReason {
@@ -578,22 +485,16 @@ impl DesmosKeeper {
                 standard_reason_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("support_standard_reason")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("standard_reason_id", standard_reason_id.to_string())
-                        .add_attribute("reason_id", 1.to_string()),
-                );
+                let events = vec![Event::new("support_standard_reason")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("standard_reason_id", standard_reason_id.to_string())
+                    .add_attribute("reason_id", 1.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReportsMsg::AddReason { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("add_reason")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("reason_id", 1.to_string()),
-                );
+                let events = vec![Event::new("add_reason")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("reason_id", 1.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReportsMsg::RemoveReason {
@@ -601,20 +502,17 @@ impl DesmosKeeper {
                 reason_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("create_post")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("reason_id", reason_id.to_string()),
-                );
+                let events = vec![Event::new("create_post")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("reason_id", reason_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
         }
     }
 
-    /// Handles [`ReactionsMsg`](crate::reactions::ReactionsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/reactions/spec/05-events.md).
+    /// Handles [`ReactionsMsg`](crate::reactions::msg::ReactionsMsg) then returns the response with proper [events](https://github.com/desmos-labs/desmos/blob/master/x/reactions/spec/05-events.md).
     #[cfg(feature = "reactions")]
-    fn handle_reactions_msg(&self, msg: ReactionsMsg) -> AnyResult<AppResponse> {
+    pub fn handle_reactions_msg(_block: &BlockInfo, msg: ReactionsMsg) -> AnyResult<AppResponse> {
         match msg {
             ReactionsMsg::AddReaction {
                 subspace_id,
@@ -622,14 +520,11 @@ impl DesmosKeeper {
                 user,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("add_reaction")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id", post_id)
-                        .add_attribute("reaction_id", 1.to_string())
-                        .add_attribute("user", user),
-                );
+                let events = vec![Event::new("add_reaction")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id", post_id)
+                    .add_attribute("reaction_id", 1.to_string())
+                    .add_attribute("user", user)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReactionsMsg::RemoveReaction {
@@ -638,22 +533,16 @@ impl DesmosKeeper {
                 reaction_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("remove_reaction")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("post_id	", post_id)
-                        .add_attribute("reaction_id", reaction_id.to_string()),
-                );
+                let events = vec![Event::new("remove_reaction")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("post_id	", post_id)
+                    .add_attribute("reaction_id", reaction_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReactionsMsg::AddRegisteredReaction { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("add_registered_reaction")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute("registered_reaction_id", 1.to_string()),
-                );
+                let events = vec![Event::new("add_registered_reaction")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("registered_reaction_id", 1.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReactionsMsg::EditRegisteredReaction {
@@ -661,15 +550,9 @@ impl DesmosKeeper {
                 registered_reaction_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("edit_registered_reaction")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute(
-                            "registered_reaction_id",
-                            registered_reaction_id.to_string(),
-                        ),
-                );
+                let events = vec![Event::new("edit_registered_reaction")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("registered_reaction_id", registered_reaction_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReactionsMsg::RemoveRegisteredReaction {
@@ -677,22 +560,15 @@ impl DesmosKeeper {
                 registered_reaction_id,
                 ..
             } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("remove_registered_reaction")
-                        .add_attribute("subspace_id", subspace_id)
-                        .add_attribute(
-                            "registered_reaction_id",
-                            registered_reaction_id.to_string(),
-                        ),
-                );
+                let events = vec![Event::new("remove_registered_reaction")
+                    .add_attribute("subspace_id", subspace_id)
+                    .add_attribute("registered_reaction_id", registered_reaction_id.to_string())];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
             ReactionsMsg::SetReactionsParams { subspace_id, .. } => {
-                let mut events = Vec::with_capacity(1);
-                events.push(
-                    Event::new("set_reactions_params").add_attribute("subspace_id", subspace_id),
-                );
+                let events =
+                    vec![Event::new("set_reactions_params")
+                        .add_attribute("subspace_id", subspace_id)];
                 AnyResult::Ok(AppResponse { events, data: None })
             }
         }
@@ -715,17 +591,17 @@ impl Module for DesmosKeeper {
     ) -> AnyResult<AppResponse> {
         match msg {
             #[cfg(feature = "profiles")]
-            DesmosMsg::Profiles(msg) => self.handle_profiles_msg(block, msg),
+            DesmosMsg::Profiles(msg) => DesmosKeeper::handle_profiles_msg(block, msg),
             #[cfg(feature = "subspaces")]
-            DesmosMsg::Subspaces(msg) => self.handle_subspaces_msg(block, msg),
+            DesmosMsg::Subspaces(msg) => DesmosKeeper::handle_subspaces_msg(block, msg),
             #[cfg(feature = "relationships")]
-            DesmosMsg::Relationships(msg) => self.handle_relationships_msg(msg),
+            DesmosMsg::Relationships(msg) => DesmosKeeper::handle_relationships_msg(block, msg),
             #[cfg(feature = "posts")]
-            DesmosMsg::Posts(msg) => self.handle_posts_msg(block, msg),
+            DesmosMsg::Posts(msg) => DesmosKeeper::handle_posts_msg(block, msg),
             #[cfg(feature = "reports")]
-            DesmosMsg::Reports(msg) => self.handle_reports_msg(block, msg),
+            DesmosMsg::Reports(msg) => DesmosKeeper::handle_reports_msg(block, msg),
             #[cfg(feature = "reactions")]
-            DesmosMsg::Reactions(msg) => self.handle_reactions_msg(msg),
+            DesmosMsg::Reactions(msg) => DesmosKeeper::handle_reactions_msg(block, msg),
         }
     }
 
@@ -737,28 +613,16 @@ impl Module for DesmosKeeper {
         _block: &BlockInfo,
         request: DesmosQuery,
     ) -> AnyResult<Binary> {
-        match request {
-            #[cfg(feature = "profiles")]
-            DesmosQuery::Profiles(query) => {
-                AnyResult::Ok(mock_profiles_query_response(&query).unwrap())
-            }
-            #[cfg(feature = "subspaces")]
-            DesmosQuery::Subspaces(query) => {
-                AnyResult::Ok(mock_subspaces_query_response(&query).unwrap())
-            }
-            #[cfg(feature = "relationships")]
-            DesmosQuery::Relationships(query) => {
-                AnyResult::Ok(mock_relationships_query_response(&query).unwrap())
-            }
-            #[cfg(feature = "posts")]
-            DesmosQuery::Posts(query) => AnyResult::Ok(mock_posts_query_response(&query).unwrap()),
-            #[cfg(feature = "reactions")]
-            DesmosQuery::Reactions(query) => {
-                AnyResult::Ok(mock_reactions_query_response(&query).unwrap())
-            }
-            #[cfg(feature = "reports")]
-            DesmosQuery::Reports(query) => {
-                AnyResult::Ok(mock_reports_query_response(&query).unwrap())
+        let request = QueryRequest::Custom(request);
+        let result = self.querier.handle_query(&request).into_result();
+
+        if let Result::Err(error) = result {
+            AnyResult::Err(error.into())
+        } else {
+            let contract_result = result.unwrap();
+            match contract_result {
+                ContractResult::Ok(binary) => AnyResult::Ok(binary),
+                ContractResult::Err(err) => AnyResult::Err(anyhow::Error::msg(err)),
             }
         }
     }

--- a/packages/bindings/src/mocks/mod.rs
+++ b/packages/bindings/src/mocks/mod.rs
@@ -1,5 +1,5 @@
 //! The test utils to mock the quriers and desmos app
 
 pub mod mock_apps;
-mod mock_keeper;
+pub mod mock_keeper;
 pub mod mock_queriers;


### PR DESCRIPTION
This PR adds the possibility to create a `DesmosKeeper` with a user provided `MockDesmosQuerier` to allow the customization of responses to quey messages in integration tests.