### PR TITLE
fix!: added missing create user group field

### DIFF
--- a/.changeset/entries/78e833354b619a94ca4e1010fdda38f24cfc7900b1ab1f51817df8bd7a52ef59.yaml
+++ b/.changeset/entries/78e833354b619a94ca4e1010fdda38f24cfc7900b1ab1f51817df8bd7a52ef59.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: none
+pull_request: 101
+description: Added missing `initial_members` field of `CreateUserGroup` message
+backward_compatible: false
+date: 2022-11-01T10:49:10.4867382Z

--- a/desmos/setup_chain.sh
+++ b/desmos/setup_chain.sh
@@ -82,7 +82,7 @@ echo $KEYRING_PASS | desmos tx wasm execute "$CONTRACT" "$MSG" \
   --chain-id=testchain --keyring-backend=file -b=block -y
 
 # Create a test user group owned by the smart contract
-MSG="{\"desmos_messages\":{\"msgs\":[{\"custom\":{\"subspaces\":{\"create_user_group\":{\"subspace_id\":\"1\",\"section_id\":null,\"name\":\"Test user group\",\"description\":null,\"initial_members\":\"[]\",\"default_permissions\":[\"EDIT_SUBSPACE\"],\"creator\":\"$CONTRACT\"}}}}]}}"
+MSG="{\"desmos_messages\":{\"msgs\":[{\"custom\":{\"subspaces\":{\"create_user_group\":{\"subspace_id\":\"1\",\"section_id\":null,\"name\":\"Test user group\",\"description\":null,\"initial_members\":[],\"default_permissions\":[\"EDIT_SUBSPACE\"],\"creator\":\"$CONTRACT\"}}}}]}}"
 echo "Create test user group"
 echo $KEYRING_PASS | desmos tx wasm execute "$CONTRACT" "$MSG" \
   --from $USER1 \

--- a/desmos/setup_chain.sh
+++ b/desmos/setup_chain.sh
@@ -82,7 +82,7 @@ echo $KEYRING_PASS | desmos tx wasm execute "$CONTRACT" "$MSG" \
   --chain-id=testchain --keyring-backend=file -b=block -y
 
 # Create a test user group owned by the smart contract
-MSG="{\"desmos_messages\":{\"msgs\":[{\"custom\":{\"subspaces\":{\"create_user_group\":{\"subspace_id\":\"1\",\"section_id\":null,\"name\":\"Test user group\",\"description\":null,\"default_permissions\":[\"EDIT_SUBSPACE\"],\"creator\":\"$CONTRACT\"}}}}]}}"
+MSG="{\"desmos_messages\":{\"msgs\":[{\"custom\":{\"subspaces\":{\"create_user_group\":{\"subspace_id\":\"1\",\"section_id\":null,\"name\":\"Test user group\",\"description\":null,\"initial_members\":\"[]\",\"default_permissions\":[\"EDIT_SUBSPACE\"],\"creator\":\"$CONTRACT\"}}}}]}}"
 echo "Create test user group"
 echo $KEYRING_PASS | desmos tx wasm execute "$CONTRACT" "$MSG" \
   --from $USER1 \

--- a/packages/bindings-test/src/subspaces/msg.rs
+++ b/packages/bindings-test/src/subspaces/msg.rs
@@ -98,6 +98,7 @@ mod tests {
                 section_id: None,
                 name: "test_user_group".to_string(),
                 description: None,
+                initial_members: vec![],
                 default_permissions: vec![Permission::EditSubspace],
                 creator: Addr::unchecked(contract_address),
             }

--- a/packages/bindings/src/subspaces/msg.rs
+++ b/packages/bindings/src/subspaces/msg.rs
@@ -102,6 +102,8 @@ pub enum SubspacesMsg {
         name: String,
         /// Description of the user group.
         description: Option<String>,
+        /// Initial members to be put inside the group.
+        initial_members: Vec<Addr>,
         /// Permissions that all the members will inherit.
         default_permissions: Vec<Permission>,
         /// Address of who wants create the user group.
@@ -345,6 +347,7 @@ impl SubspacesMsg {
         name: String,
         description: Option<String>,
         default_permissions: Vec<Permission>,
+        initial_members: Vec<Addr>,
         creator: Addr,
     ) -> SubspacesMsg {
         SubspacesMsg::CreateUserGroup {
@@ -352,6 +355,7 @@ impl SubspacesMsg {
             section_id,
             name,
             description,
+            initial_members,
             default_permissions,
             creator,
         }
@@ -633,6 +637,7 @@ mod tests {
             "test".to_string(),
             Some("test".to_string()),
             vec![],
+            vec![],
             Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
         );
         let expected = SubspacesMsg::CreateUserGroup {
@@ -640,6 +645,7 @@ mod tests {
             section_id: Some(1),
             name: "test".to_string(),
             description: Some("test".to_string()),
+            initial_members: vec![],
             default_permissions: vec![],
             creator: Addr::unchecked("cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
         };


### PR DESCRIPTION
This PR fixes the missing `initial_members` field of `CreateUserGroup`.