### PR TITLE
ci: enabled desmos ref setting

### DIFF
--- a/.github/workflows/chain_interaction.yml
+++ b/.github/workflows/chain_interaction.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: desmos-labs/desmos
-          #ref: refs/tags/v4.3.0
+          ref: refs/tags/v4.7.1
           path: ./desmos-src
   
       - name: Build desmos chain ⚙


### PR DESCRIPTION
This PR enables desmos ref setting in order to fix the wrong version of desmos binary in workflow checks.