### PR TITLE
build(deps): bump std-derive syn to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2",
- "syn 2.0.12",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1028,7 +1028,7 @@ dependencies = [
  "prost-types",
  "quote",
  "regex",
- "syn 2.0.12",
+ "syn 2.0.15",
  "walkdir",
 ]
 
@@ -1219,7 +1219,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1305,7 +1305,7 @@ dependencies = [
  "prost 0.11.8",
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.15",
  "trybuild",
 ]
 
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/packages/proto-build/Cargo.toml
+++ b/packages/proto-build/Cargo.toml
@@ -15,6 +15,6 @@ prost-build = "0.11.1"
 prost-types = "0.11.1"
 quote = "1.0.26"
 regex = "1"
-syn = {version = "2.0.5", features = ["full", "parsing", "extra-traits"]}
+syn = {version = "2.0.15", features = ["full", "parsing", "extra-traits"]}
 walkdir = "2"
 proc-macro2 = "1.0.56"

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -8,7 +8,10 @@ use prost_types::{
     DescriptorProto, EnumDescriptorProto, FileDescriptorSet, ServiceDescriptorProto,
 };
 use regex::Regex;
-use syn::{parse_quote, Attribute, Fields, Ident, Item, ItemEnum, ItemImpl, ItemStruct, Type, punctuated::Punctuated, Token, Meta};
+use syn::{
+    parse_quote, punctuated::Punctuated, Attribute, Fields, Ident, Item, ItemEnum, ItemImpl,
+    ItemStruct, Meta, Token, Type,
+};
 
 use crate::{format_ident, quote};
 
@@ -455,10 +458,12 @@ fn find_prost_enumeration_value(attrs: &[Attribute]) -> Option<String> {
         }
 
         let list = attr.meta.require_list().unwrap();
-    
+
         // Search all nested attributes and look for the "enumeration" attribute, then getting its value.
-        let nested = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated).unwrap();
-        
+        let nested = list
+            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            .unwrap();
+
         nested.iter().find_map(|meta| {
             if let syn::Meta::NameValue(nv) = meta {
                 if !nv.path.is_ident("enumeration") {
@@ -471,17 +476,9 @@ fn find_prost_enumeration_value(attrs: &[Attribute]) -> Option<String> {
                     }
                 }
             }
-            
+
             None
         })
-        .unwrap_or_else(|e| {
-            // Do nothing if the error is "expected `,`"
-            if e.to_string() != "expected `,`".to_string() {
-                panic!("{}", e)
-            }
-        });
-
-        enumeration_value
     })
 }
 
@@ -494,8 +491,10 @@ fn has_prost_one_of_attr(attrs: &[Attribute]) -> bool {
         let list = attr.meta.require_list().unwrap();
 
         // Search all nested attributes and look for the "oneof" attribute.
-        let nested = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated).unwrap();
-        
+        let nested = list
+            .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            .unwrap();
+
         nested.iter().any(|meta| meta.path().is_ident("oneof"))
     })
 }

--- a/packages/proto-build/src/transformers.rs
+++ b/packages/proto-build/src/transformers.rs
@@ -457,13 +457,13 @@ fn find_prost_enumeration_value(attrs: &[Attribute]) -> Option<String> {
             return None;
         }
 
+        // Parse all nested items inside the attribute
         let list = attr.meta.require_list().unwrap();
-
-        // Search all nested attributes and look for the "enumeration" attribute, then getting its value.
         let nested = list
             .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
             .unwrap();
 
+        // Search all nested items and look for the "enumeration" attribute, then getting its value.
         nested.iter().find_map(|meta| {
             if let syn::Meta::NameValue(nv) = meta {
                 if !nv.path.is_ident("enumeration") {
@@ -488,13 +488,14 @@ fn has_prost_one_of_attr(attrs: &[Attribute]) -> bool {
         if !attr.path().is_ident("prost") {
             return false;
         }
-        let list = attr.meta.require_list().unwrap();
 
-        // Search all nested attributes and look for the "oneof" attribute.
+        // Parse all nested items inside the attribute
+        let list = attr.meta.require_list().unwrap();
         let nested = list
             .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
             .unwrap();
 
+        // Search all nested items and look for the "oneof" attribute.
         nested.iter().any(|meta| meta.path().is_ident("oneof"))
     })
 }

--- a/packages/std-derive/Cargo.toml
+++ b/packages/std-derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 itertools = "0.10.3"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
-syn = "1.0.98"
+syn = "2.0.15"
 
 [dev-dependencies]
 cosmwasm-std = {version = "1.2.4", features = ["stargate"]}


### PR DESCRIPTION
Close #188

This PR bumps `syn` to latest version 2.0.15, and also solve the bindly skip parse nested error issue.