### PR TITLE
ci: fix release ci

### DIFF
--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -22,22 +22,7 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Publish desmos-mock to crates.io 📤
-        uses: katyo/publish-crates@v1
+      - name: Publish crates.io 📤
+        uses: katyo/publish-crates@v2
         with:
-          path: './packages/mock'
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          ignore-unpublished-changes: true
-
-      - name: Publish desmos-std-derive to crates.io 📤
-        uses: katyo/publish-crates@v1
-        with:
-          path: './packages/std-derive'
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          ignore-unpublished-changes: true
-
-      - name: Publish desmos-bindings to crates.io 📤
-        uses: katyo/publish-crates@v1
-        with:
-          path: './packages/bindings'
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/contracts/test-contract/Cargo.toml
+++ b/contracts/test-contract/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-contract"
 version = "1.0.0"
 authors = ["Manuel Turetta <manuel.turetta94@gmail.com>"]
 edition = "2018"
+publish = false
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bindings-test"
 version = "1.0.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/proto-build/Cargo.toml
+++ b/packages/proto-build/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 edition = "2021"
 name = "proto-build"
-publish = false
 version = "0.1.0"
+publish = false
 
 [dependencies]
 heck = "0.4.0"

--- a/scripts/tx.sh
+++ b/scripts/tx.sh
@@ -9,7 +9,7 @@ desmos() {
 	"$SCRIPT_DIR/desmos" --home="$DESMOS_HOME" "$@"
 
 	# Wait tx including block
-	sleep 1
+	sleep 2
 }
 
 echo $KEYRING_PASS | desmos tx "$@" --keyring-backend=file -b=sync -y

--- a/scripts/upload_test_contract.sh
+++ b/scripts/upload_test_contract.sh
@@ -15,7 +15,7 @@ desmos() {
 	"$SCRIPT_DIR/desmos" --home="$DESMOS_HOME" "$@"
   
   # Wait tx including block
-  sleep 1
+  sleep 2
 }
 
 # Force the script to exit at the first error


### PR DESCRIPTION
For some reasons, `katyo/publish-crates@v1` release does not work properly, so updated to `katyo/publish-crates@v2`.
See:
https://github.com/desmos-labs/desmos-bindings/actions/runs/5196172696/jobs/9369823915#step:4:15

In addition, `publish-crates@v2` only read main workplace `Cargo.toml` to publish everything, so `publish = false` is added to the unpublished packages config file.

The result of this change will be as follows: 
https://github.com/desmos-labs/desmos-bindings/actions/runs/5196458053/jobs/9370180554