### PR TITLE
ci: set ci timeout

### DIFF
--- a/.github/workflows/chain-interaction.yml
+++ b/.github/workflows/chain-interaction.yml
@@ -7,7 +7,7 @@ jobs:
   chain_interaction:
     name: Test interaction with chain
     runs-on: ubuntu-latest
-
+    timeout-minutes: 30
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,7 @@ jobs:
   coverage:
     name: Upload coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 6
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2

--- a/.github/workflows/desmos-bindings.yml
+++ b/.github/workflows/desmos-bindings.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    timeout-minutes: 6
     steps:
       - uses: amannn/action-semantic-pull-request@v4.5.0
         env:

--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     name: Publish Desmos bindings on crates.io
     runs-on: ubuntu-latest
-
+    timeout-minutes: 6
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR set ci timeout to avoid from using unexpected long time of a action job like this:
https://github.com/desmos-labs/desmos-bindings/actions/runs/5374726520/attempts/1