### PR TITLE
build(deps): Bump cosmwasm-std from 1.2.7 to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,9 +194,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb64554a91d6a9231127f4355d351130a0b94e663d5d9dc8b3a54ca17d83de49"
+checksum = "0d076a08ec01ed23c4396aca98ec73a38fa1fee5f310465add52b4108181c7a8"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -201,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fb2ce09f41a3dae1a234d56a9988f9aff4c76441cd50ef1ee9a4f20415b028"
+checksum = "dec361f3c09d7b41221948fc17be9b3c96cb58e55a02f82da36f888a651f2584"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -234,11 +240,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4337eef8dfaf8572fe6b6b415d6ec25f9308c7bb09f2da63789209fb131363be"
+checksum = "1f6dc2ee23313add5ecacc3ccac217b9967ad9d2d11bd56e5da6aa65a9da6138"
 dependencies = [
  "base64 0.13.1",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
@@ -249,7 +256,6 @@ dependencies = [
  "serde-json-wasm",
  "sha2 0.10.6",
  "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -260,12 +266,6 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -1322,12 +1322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strum_macros"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,18 +1447,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/contracts/test-contract/Cargo.toml
+++ b/contracts/test-contract/Cargo.toml
@@ -31,7 +31,7 @@ optimize = """docker run --rm \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.2.7", features = ["stargate"]}
+cosmwasm-std = { version = "1.3.0", features = ["stargate"]}
 cw2 = "1.1.0"
 thiserror = { version = "1.0" }
 desmos-bindings = { path = "../../packages/bindings", version = "2.0.0" }

--- a/contracts/test-contract/Cargo.toml
+++ b/contracts/test-contract/Cargo.toml
@@ -25,9 +25,9 @@ library = []
 [package.metadata.scripts]
 optimize = """docker run --rm \
   -v "$(pwd)/../..":/code \
-  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.6 ./contracts/test-contract
+  cosmwasm/workspace-optimizer:0.13.0 ./contracts/test-contract
 """
 
 [dependencies]

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.2.7", features = ["stargate"]}
+cosmwasm-std = { version = "1.3.0", features = ["stargate"]}
 desmos-bindings = { path = "../bindings", version = "2.0.0" }
 test-contract = { path = "../../contracts/test-contract", version = "1.0.0" }
 serde = "1.0.171"

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 
 [dependencies]
 chrono = {version = "0.4.26", default-features = false}
-cosmwasm-std = { version = "1.2.7", features = ["stargate"]}
+cosmwasm-std = { version = "1.3.0", features = ["stargate"]}
 cosmwasm-schema = "1.3.0"
 serde = { version = "1.0.171", default-features = false, features = ["derive"] }
 prost = {version = "0.11.0", default-features = false, features = ["prost-derive"]}

--- a/packages/mock/Cargo.toml
+++ b/packages/mock/Cargo.toml
@@ -8,5 +8,5 @@ version = "2.0.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = {version = "1.2.7", features = ["stargate"]}
+cosmwasm-std = {version = "1.3.0", features = ["stargate"]}
 

--- a/packages/std-derive/Cargo.toml
+++ b/packages/std-derive/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0.29"
 syn = "2.0.26"
 
 [dev-dependencies]
-cosmwasm-std = {version = "1.2.7", features = ["stargate"]}
+cosmwasm-std = {version = "1.3.0", features = ["stargate"]}
 prost = "0.11"
 serde = "1.0.171"
 trybuild = {version = "1.0.81", features = ["diff"]}


### PR DESCRIPTION
Close: #259 

This PR bumps cosmwasm-std to 1.3.0, and it also requires that rust-optimizer update to 0.13.0. See:
https://github.com/CosmWasm/rust-optimizer#contracts-as-workspace-members