### PR TITLE
chore: use `parse_err` constructor instead of literal

### DIFF
--- a/.changeset/entries/a3a03845f1085a3da924a0d48573308098377d6fd65a0dce328de56c261bf9e1.yaml
+++ b/.changeset/entries/a3a03845f1085a3da924a0d48573308098377d6fd65a0dce328de56c261bf9e1.yaml
@@ -1,0 +1,6 @@
+type: refactor
+module: none
+pull_request: 291
+description: Use `parse_err` constructor instead of literal
+backward_compatible: false
+date: 2023-08-18T07:06:29.63239721Z

--- a/packages/std-derive/Cargo.toml
+++ b/packages/std-derive/Cargo.toml
@@ -7,9 +7,6 @@ version = "2.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-backtraces = ["cosmwasm-std/backtraces"]
-
 [lib]
 proc-macro = true
 

--- a/packages/std-derive/src/lib.rs
+++ b/packages/std-derive/src/lib.rs
@@ -111,21 +111,18 @@ pub fn derive_cosmwasm_ext(input: TokenStream) -> TokenStream {
             fn try_from(binary: cosmwasm_std::Binary) -> std::result::Result<Self, Self::Error> {
                 use ::prost::Message;
                 Self::decode(&binary[..]).map_err(|e| {
-                    cosmwasm_std::StdError::ParseErr {
-                        target_type: stringify!(#ident).to_string(),
-                        msg: format!(
-                            "Unable to decode binary: \n  - base64: {}\n  - bytes array: {:?}\n\n{:?}",
-                            binary,
-                            binary.to_vec(),
-                            e
-                        ),
-                        #[cfg(feature = "backtraces")]
-                        backtrace: std::backtrace::Backtrace::capture(),
-                    }
+                    cosmwasm_std::StdError::parse_err(stringify!(#ident).to_string(),
+                    format!(
+                        "Unable to decode binary: \n  - base64: {}\n  - bytes array: {:?}\n\n{:?}",
+                        binary,
+                        binary.to_vec(),
+                        e
+                    ))
                 })
             }
         }
-    }).into()
+    })
+    .into()
 }
 
 fn get_type_url(attrs: &Vec<syn::Attribute>) -> proc_macro2::TokenStream {


### PR DESCRIPTION
This PR applied `parse_err` constructor, it reduces a feature inside `desmos-std-derive`.

See: https://github.com/CosmWasm/cosmwasm/issues/1760