### PR TITLE
chore: disable backtraces features

### DIFF
--- a/.changeset/entries/6ac1a92374f9348537b8316a32e279fb79dbaa558d8a995447ff301033eaae9f.yaml
+++ b/.changeset/entries/6ac1a92374f9348537b8316a32e279fb79dbaa558d8a995447ff301033eaae9f.yaml
@@ -1,0 +1,6 @@
+type: refactor
+module: none
+pull_request: 296
+description: Disable backtraces feature
+backward_compatible: false
+date: 2023-08-18T07:04:10.019998784Z

--- a/.github/workflows/chain-interaction.yml
+++ b/.github/workflows/chain-interaction.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: 1.71.1
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
         if: env.GIT_DIFF
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.71.1
           override: true
 
       - name: Prepare rust cache 🗄️

--- a/.github/workflows/desmos-bindings.yml
+++ b/.github/workflows/desmos-bindings.yml
@@ -28,7 +28,7 @@ jobs:
         if: env.GIT_DIFF
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.71.1
           profile: minimal
           override: true
 
@@ -62,7 +62,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: 1.71.1
           override: true
           components: rustfmt, clippy
 
@@ -99,7 +99,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: 1.71.1
           override: true
           components: rustfmt, clippy
 
@@ -172,7 +172,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: 1.71.1
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: 1.71.1
           override: true
           components: rustfmt, clippy
 

--- a/contracts/test-contract/Cargo.toml
+++ b/contracts/test-contract/Cargo.toml
@@ -17,8 +17,10 @@ exclude = [
 crate-type = ["cdylib", "rlib"]
 
 [features]
+# TODO: Enable backtraces feature when it becomes stable feature
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
+# backtraces = ["cosmwasm-std/backtraces"]
+
 # use library feature to disable all instantiate/execute/query exports
 library = []
 

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -46,4 +46,5 @@ relationships = []
 reports = []
 reactions = []
 iterators = []
-backtraces = ["cosmwasm-std/backtraces", "desmos-std-derive/backtraces"]
+# TODO: Enable backtraces feature when it becomes stable feature
+# backtraces = ["cosmwasm-std/backtraces"]


### PR DESCRIPTION
This PR disabled `backtraces` features since it depends on Rust nightly version. Besides, currently the latest nightly version has issues so it makes building `cosmwasm-std` failed.
We can enable it again as soon as the feature is stable.